### PR TITLE
:books: [CppCon-2018] PDF slides generation

### DIFF
--- a/doc/cppcon-2018/index.html
+++ b/doc/cppcon-2018/index.html
@@ -16,16 +16,23 @@
 			var link = document.createElement( 'link' );
 			link.rel = 'stylesheet';
 			link.type = 'text/css';
-			link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
+			link.href = window.location.search.match( /print-pdf/gi ) ? 'reveal.js/css/print/pdf.css' : 'reveal.js/css/print/paper.css';
 			document.getElementsByTagName( 'head' )[0].appendChild( link );
-		</script>
 
-		<script>
       function set_address(self, remote, local) {
         if (window.location.search.match("local")) {
           self.setAttribute('data-src', local);
         } else {
           self.setAttribute('data-src', remote);
+
+          if (window.location.search.match( /print-pdf/gi ) &&
+             !self.parentNode.getElementsByTagName('a').length) {
+            self.style.display = 'none';
+            var link = document.createElement('a');
+            link.href = remote;
+            link.innerHTML = remote;
+            self.parentNode.appendChild(link);
+          }
         }
       }
 		</script>


### PR DESCRIPTION
Problem:
- PDF slides generation out of reveal.js doesn't work.

Solution:
- Fix the CSS location and use link instead of iframe in case of pdf.