### PR TITLE
:books: :bug: Fix #222 - Documentation bugs

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -119,7 +119,7 @@ to avoid it `[Boost].SML` may suit you!
 
 ###Related materials
 
-* [CppCon 2018 - Kris Jusiak - State Machines Battlefield - Naive vs STL vs Boost](http://boost-experimental.github.io/sml/cppcon-2018)
+* [CppCon 2018 - Kris Jusiak - State Machines Battlefield - Naive vs STL vs Boost](https://www.youtube.com/watch?v=yZVby-PuXM0)
 * [C++Now 2018 - Michael Caisse - “Modern C++ in Embedded Systems”](https://youtu.be/c9Xt6Me3mJ4?t=4378)
 * [EmBO++ 2018 - Kris Jusiak - Workshop - 'Embedding' a Meta State Machine](http://boost-experimental.github.io/sml/embo-2018)
 * [EmBO++ 2018 - Simon Brand - Embedded DSLs for embedded programming](https://youtu.be/YQoXjqm2hiE?t=705)

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -172,7 +172,7 @@ using namespace sml; // Postfix Notation
 
 make_transition_table(
  *"src_state"_s + event<my_event> [ guard ] / action = "dst_state"_s
-, "dst_state"_s + "other_event"_t = X
+, "dst_state"_s + "other_event"_e = X
 );
 ```
 
@@ -183,7 +183,7 @@ using namespace sml; // Prefix Notation
 
 make_transition_table(
   "dst_state"_s <= *"src_state"_s + event<my_event> [ guard ] / action
-, X             <= "dst_state"_s  + "other_event"_t
+, X             <= "dst_state"_s  + "other_event"_e
 );
 ```
 
@@ -358,13 +358,13 @@ make_transition_table(
 );
 ```
 
-Any unexpected event might be handled too by using `unexpected_event<>`.
+Any unexpected event might be handled too by using `unexpected_event<_>`.
 
 ```cpp
 make_transition_table(
  *"src_state"_s + event<my_event> [ guard ] / action = "dst_state"_s
 , "src_state"_s + unexpected_event<some_event> / [] { std::cout << "unexpected 'some_event' << '\n'; "}
-, "src_state"_s + unexpected_event<> = X // any event
+, "src_state"_s + unexpected_event<_> = X // any event
 );
 ```
 


### PR DESCRIPTION
Problem:
- There are some typos in the documentation:
  * Under 3. Create a transition table, "other_event"_t should be "other_event"_e.
  * Under 8. Handle errors, unexpected_event<> should be unexpected_event<_>.
- "CppCon 2018 - Kris Jusiak - State Machines Battlefield - Naive vs STL vs Boost" is available on youtube.

Solution:
- Fix the typos.
- Add link to the youtube video.