### PR TITLE
Reduce compilation RAM usage

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1308,7 +1308,7 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   using history_states_t = aux::apply_t<get_history_states, transitions_t>;
   using has_history_states =
       aux::integral_constant<bool, aux::size<initial_states_t>::value != aux::size<history_states_t>::value>;
-  using sub_internal_events_t = aux::apply_t<get_sub_internal_events, transitions_t>;
+  using sub_internal_events_t = aux::apply_t<aux::unique_t, aux::apply_t<get_sub_internal_events, transitions_t>>;
   using events_t = aux::apply_t<aux::unique_t, aux::join_t<sub_internal_events_t, aux::apply_t<get_all_events, transitions_t>>>;
   using events_ids_t = aux::apply_t<aux::inherit, events_t>;
   using has_unexpected_events = typename aux::is_base_of<unexpected, aux::apply_t<aux::inherit, events_t>>::type;

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -216,7 +216,7 @@ struct remove_reference<T &&> {
 };
 template <class T>
 using remove_reference_t = typename remove_reference<T>::type;
-}
+}  // namespace aux
 namespace aux {
 using swallow = int[];
 template <int...>
@@ -278,27 +278,27 @@ template <class... TArgs>
 using join_t = typename join<TArgs...>::type;
 template <class, class...>
 struct unique_impl;
-template <class T1, class T2, class... Rs, class... Ts>
-struct unique_impl<type<T1, Rs...>, T2, Ts...>
-    : conditional_t<is_base_of<type<T2>, T1>::value, unique_impl<type<inherit<T1>, Rs...>, Ts...>,
-                    unique_impl<type<inherit<T1, type<T2>>, Rs..., T2>, Ts...>> {};
-template <class T1, class... Rs>
-struct unique_impl<type<T1, Rs...>> : type_list<Rs...> {};
+template <class T, class... Rs, class... Ts>
+struct unique_impl<type<Rs...>, T, Ts...> : conditional_t<is_base_of<type<T>, inherit<type<Rs>...>>::value,
+                                                          unique_impl<type<Rs...>, Ts...>, unique_impl<type<Rs..., T>, Ts...>> {
+};
+template <class... Rs>
+struct unique_impl<type<Rs...>> : type_list<Rs...> {};
 template <class... Ts>
-struct unique : unique_impl<type<none_type>, Ts...> {};
+struct unique : unique_impl<type<>, Ts...> {};
 template <class T>
 struct unique<T> : type_list<T> {};
 template <class... Ts>
 using unique_t = typename unique<Ts...>::type;
-template <class, class...>
+template <class...>
 struct is_unique;
 template <class T>
 struct is_unique<T> : true_type {};
-template <class T1, class T2, class... Ts>
-struct is_unique<T1, T2, Ts...>
-    : conditional_t<is_base_of<type<T2>, T1>::value, false_type, is_unique<inherit<T1, type<T2>>, Ts...>> {};
+template <class T, class... Rs, class... Ts>
+struct is_unique<type<Rs...>, T, Ts...>
+    : conditional_t<is_base_of<type<T>, inherit<type<Rs>...>>::value, false_type, is_unique<type<Rs..., T>, Ts...>> {};
 template <class... Ts>
-using is_unique_t = is_unique<none_type, Ts...>;
+using is_unique_t = is_unique<type<>, Ts...>;
 template <template <class...> class, class>
 struct apply;
 template <template <class...> class T, template <class...> class U, class... Ts>
@@ -480,7 +480,7 @@ auto get_type_name(const char *ptr, index_sequence<Ns...>) {
   static const char str[] = {ptr[N + Ns]..., 0};
   return str;
 }
-}
+}  // namespace detail
 template <class T>
 const char *get_type_name() {
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -525,7 +525,7 @@ struct string<T> {
   }
   static auto c_str_impl(...) { return get_type_name<T>(); }
 };
-}
+}  // namespace aux
 namespace back {
 namespace policies {
 struct defer_queue_policy__ {};
@@ -535,8 +535,8 @@ struct defer_queue : aux::pair<back::policies::defer_queue_policy__, defer_queue
   using rebind = T<U>;
   using flag = bool;
 };
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 template <class... Ts>
 class queue_event {
@@ -627,7 +627,7 @@ struct deque_handler : queue_event_call<TEvents>... {
   }
   void *deque_{};
 };
-}
+}  // namespace back
 namespace back {
 struct _ {};
 struct initial {};
@@ -709,7 +709,7 @@ template <class... TEvents>
 struct defer : deque_handler<TEvents...> {
   using deque_handler<TEvents...>::deque_handler;
 };
-}
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -832,7 +832,7 @@ template <class T, class... Ts>
 struct convert_to_sm<T, aux::type_list<Ts...>> {
   using type = aux::type_list<sm_impl<T>, sm_impl<typename T::template rebind<Ts>>...>;
 };
-}
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -918,7 +918,7 @@ struct transitions_sub<sm<TSM>> {
     return sub_sm<sm_impl<TSM>>::get(&subs).template process_event<TEvent>(event, deps, subs);
   }
 };
-}
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -1036,7 +1036,7 @@ struct get_event_mapping_impl_helper<on_exit<T1, T2>, TMappings>
     : decltype(get_event_mapping_impl<on_exit<T1, T2>>((TMappings *)0)) {};
 template <class T, class TMappings>
 using get_event_mapping_t = get_event_mapping_impl_helper<T, TMappings>;
-}
+}  // namespace back
 namespace back {
 namespace policies {
 struct dispatch_policy__ {};
@@ -1111,8 +1111,8 @@ struct fold_expr {
   }
 };
 #endif
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -1179,8 +1179,8 @@ void log_guard(const aux::type<TLogger> &, TDeps &deps, const aux::zero_wrapper<
                bool result) {
   return static_cast<aux::pool_type<TLogger &> &>(deps).value.template log_guard<SM>(guard.get(), event, result);
 }
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 namespace policies {
 struct process_queue_policy__ {};
@@ -1189,14 +1189,14 @@ struct process_queue : aux::pair<back::policies::process_queue_policy__, process
   template <class U>
   using rebind = T<U>;
 };
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 namespace policies {
 struct testing_policy__ {};
 struct testing : aux::pair<testing_policy__, testing> {};
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 namespace policies {
 struct thread_safety_policy__ {
@@ -1216,8 +1216,8 @@ struct thread_safe : aux::pair<thread_safety_policy__, thread_safe<TLock>> {
   }
   TLock lock;
 };
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 struct no_policy : policies::thread_safety_policy__ {
   using type = no_policy;
@@ -1256,7 +1256,7 @@ struct sm_policy {
   template <class T>
   using rebind = typename rebind_impl<T, TPolicies...>::type;
 };
-}
+}  // namespace back
 namespace concepts {
 struct callable_fallback {
   void operator()();
@@ -1272,7 +1272,7 @@ template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...)> : aux::true_type {};
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const> : aux::true_type {};
-}
+}  // namespace concepts
 namespace concepts {
 template <class T>
 decltype(aux::declval<T>().operator()()) composable_impl(int);
@@ -1280,7 +1280,7 @@ template <class>
 void composable_impl(...);
 template <class T>
 struct composable : aux::is<aux::pool, decltype(composable_impl<T>(0))> {};
-}
+}  // namespace concepts
 #if !defined(BOOST_SML_DISABLE_EXCEPTIONS)
 #if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
 #define BOOST_SML_DISABLE_EXCEPTIONS true
@@ -1756,7 +1756,7 @@ class sm {
   deps_t deps_;
   sub_sms_t sub_sms_;
 };
-}
+}  // namespace back
 namespace front {
 struct operator_base {};
 struct action_base {};
@@ -1988,7 +1988,7 @@ class not_ : operator_base {
  private:
   T g;
 };
-}
+}  // namespace front
 template <class T, __BOOST_SML_REQUIRES(concepts::callable<bool, T>::value)>
 auto operator!(const T &t) {
   return front::not_<aux::zero_wrapper<T>>(aux::zero_wrapper<T>{t});
@@ -2017,8 +2017,8 @@ struct defer : action_base {
     }
   }
 };
-}
-}
+}  // namespace actions
+}  // namespace front
 using testing = back::policies::testing;
 template <class T>
 using logger = back::policies::logger<T>;
@@ -2044,7 +2044,7 @@ auto transitional_impl(T &&t) -> aux::always<typename T::dst_state, typename T::
                                              decltype(T::initial), decltype(T::history)>;
 template <class T>
 struct transitional : decltype(transitional_impl(aux::declval<T>())) {};
-}
+}  // namespace concepts
 namespace front {
 namespace actions {
 struct process {
@@ -2065,8 +2065,8 @@ struct process {
     return process_impl<TEvent>{event};
   }
 };
-}
-}
+}  // namespace actions
+}  // namespace front
 namespace front {
 template <class, class>
 struct transition_eg;
@@ -2084,7 +2084,7 @@ struct event {
   }
   auto operator()() const { return TEvent{}; }
 };
-}
+}  // namespace front
 namespace front {
 struct initial_state {};
 struct history_state {};
@@ -2177,7 +2177,7 @@ struct state_sm<T, aux::enable_if_t<concepts::composable<T>::value>> {
   using type = state<back::sm<back::sm_policy<T>>>;
 };
 #endif
-}
+}  // namespace front
 namespace front {
 struct internal {};
 template <class, class>
@@ -2627,7 +2627,7 @@ struct transition<state<internal>, state<S2>, front::event<E>, always, none> {
   }
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
 };
-}
+}  // namespace front
 using _ = back::_;
 #if !(defined(_MSC_VER) && !defined(__clang__))
 template <class TEvent>
@@ -2675,7 +2675,7 @@ constexpr auto operator""_e() {
   return event<aux::string<T, Chrs...>>;
 }
 #endif
-}
+}  // namespace literals
 __BOOST_SML_UNUSED static front::state<back::terminate_state> X;
 __BOOST_SML_UNUSED static front::history_state H;
 __BOOST_SML_UNUSED static front::actions::defer defer;

--- a/include/boost/sml/aux_/utility.hpp
+++ b/include/boost/sml/aux_/utility.hpp
@@ -76,31 +76,35 @@ using join_t = typename join<TArgs...>::type;
 
 template <class, class...>
 struct unique_impl;
-template <class T1, class T2, class... Rs, class... Ts>
-struct unique_impl<type<T1, Rs...>, T2, Ts...>
-    : conditional_t<is_base_of<type<T2>, T1>::value, unique_impl<type<inherit<T1>, Rs...>, Ts...>,
-                    unique_impl<type<inherit<T1, type<T2>>, Rs..., T2>, Ts...>> {};
-template <class T1, class... Rs>
-struct unique_impl<type<T1, Rs...>> : type_list<Rs...> {};
+
+template <class T, class... Rs, class... Ts>
+struct unique_impl<type<Rs...>, T, Ts...>
+    : conditional_t<is_base_of<type<T>, inherit<type<Rs>...>>::value, unique_impl<type<Rs...>, Ts...>,
+                    unique_impl<type<Rs..., T>, Ts...>> {};
+
+template <class... Rs>
+struct unique_impl<type<Rs...>> : type_list<Rs...> {};
+
+
 template <class... Ts>
-struct unique : unique_impl<type<none_type>, Ts...> {};
+struct unique : unique_impl<type<>, Ts...> {};
 template <class T>
 struct unique<T> : type_list<T> {};
 template <class... Ts>
 using unique_t = typename unique<Ts...>::type;
 
-template <class, class...>
+template <class...>
 struct is_unique;
 
 template <class T>
 struct is_unique<T> : true_type {};
 
-template <class T1, class T2, class... Ts>
-struct is_unique<T1, T2, Ts...>
-    : conditional_t<is_base_of<type<T2>, T1>::value, false_type, is_unique<inherit<T1, type<T2>>, Ts...>> {};
+template <class T, class... Rs, class... Ts>
+struct is_unique<type<Rs...>, T, Ts...>
+    : conditional_t<is_base_of<type<T>, inherit<type<Rs>...>>::value, false_type, is_unique<type<Rs..., T>, Ts...>> {};
 
 template <class... Ts>
-using is_unique_t = is_unique<none_type, Ts...>;
+using is_unique_t = is_unique<type<>, Ts...>;
 
 template <template <class...> class, class>
 struct apply;

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -45,7 +45,7 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   using history_states_t = aux::apply_t<get_history_states, transitions_t>;
   using has_history_states =
       aux::integral_constant<bool, aux::size<initial_states_t>::value != aux::size<history_states_t>::value>;
-  using sub_internal_events_t = aux::apply_t<get_sub_internal_events, transitions_t>;
+  using sub_internal_events_t = aux::apply_t<aux::unique_t, aux::apply_t<get_sub_internal_events, transitions_t>>;
   using events_t = aux::apply_t<aux::unique_t, aux::join_t<sub_internal_events_t, aux::apply_t<get_all_events, transitions_t>>>;
   using events_ids_t = aux::apply_t<aux::inherit, events_t>;
   using has_unexpected_events = typename aux::is_base_of<unexpected, aux::apply_t<aux::inherit, events_t>>::type;

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -22,6 +22,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # gcc
     add_test(test_dependencies test_dependencies)
 endif()
 
+add_executable(test_deep_sm deep_sm.cpp)
+
 add_executable(test_di di.cpp)
 add_test(test_di test_di)
 

--- a/test/ft/deep_sm.cpp
+++ b/test/ft/deep_sm.cpp
@@ -1,0 +1,137 @@
+//
+// Copyright (c) 2016-2019 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+/*
+The goal of this file is only to compile a state machine with deeply nested
+states that use on_entry events. The only requirement on this file is a
+successful compilation without a ftemplate-depth error.
+*/
+#include <boost/sml.hpp>
+
+namespace sml = boost::sml;
+using namespace sml;
+
+struct e0 {};
+struct e1 {};
+struct e2 {};
+struct e3 {};
+struct e4 {};
+struct e5 {};
+struct e6 {};
+struct e7 {};
+struct e8 {};
+struct e9 {};
+struct e10 {};
+
+struct s0 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<struct run_>;
+    return make_transition_table(
+        *idle + event<e0> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s1 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s0>;
+    return make_transition_table(
+        *idle + event<e1> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s2 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s1>;
+    return make_transition_table(
+        *idle + event<e2> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s3 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s2>;
+    return make_transition_table(
+        *idle + event<e3> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s4 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s3>;
+    return make_transition_table(
+        *idle + event<e4> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s5 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s4>;
+    return make_transition_table(
+        *idle + event<e5> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s6 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s5>;
+    return make_transition_table(
+        *idle + event<e6> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s7 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s6>;
+    return make_transition_table(
+        *idle + event<e7> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s8 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s7>;
+    return make_transition_table(
+        *idle + event<e8> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s9 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s8>;
+    return make_transition_table(
+        *idle + event<e9> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct s10 {
+  auto operator()() noexcept {
+    auto idle = state<struct idle_>;
+    auto run = state<s9>;
+    return make_transition_table(
+        *idle + event<e10> = run, run + on_entry<_> / [] {});
+  }
+};
+
+struct DeepSM {
+  auto operator()() noexcept { return make_transition_table(*state<struct idle> = state<s10>); }
+};
+
+test deep_sm = [] {
+  sm<DeepSM> state_machine;
+  state_machine.process_event(e0{});
+};


### PR DESCRIPTION
SML RAM usage and template depth during compilation can be reduced by doing small optimization on type declaration.

Optimization done here :
- Small optimization on unique_t impl
- Early calculation of unique events list in sm_impl. (This greatly reduce template depth)

The problems were linked to state machine with some depth since problem grow exponentially with depth.  
Test case do not cover deep SM. 