### PR TITLE
Exponential anonymous event processing

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1345,11 +1345,11 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
         process_event_noexcept<get_event_mapping_t<get_generic_t<TEvent>, mappings>>(event, deps, subs, has_exceptions{});
 #endif
     do {
-      while (process_internal_events(anonymous{}, deps, subs)) {
-      }
-      process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{});
-    } while (process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{}) ||
-             process_internal_events(anonymous{}, deps, subs));
+      do {
+        while (process_internal_events(anonymous{}, deps, subs)) {
+        }
+      } while (process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{}));
+    } while (process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{}));
     return handled;
   }
   void initialize(const aux::type_list<> &) {}
@@ -1531,6 +1531,7 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
 #endif
     if (handled && defer_again_) {
       ++defer_it_;
+      return false;
     } else {
       defer_.erase(defer_it_);
       defer_it_ = defer_.begin();
@@ -1550,9 +1551,8 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
       defer_again_ = false;
       defer_it_ = defer_.begin();
       defer_end_ = defer_.end();
-      processed_events = defer_it_ != defer_end_;
       while (defer_it_ != defer_end_) {
-        (this->*dispatch_table[defer_it_->id])(deps, subs, defer_it_->data);
+        processed_events |= (this->*dispatch_table[defer_it_->id])(deps, subs, defer_it_->data);
         defer_again_ = false;
       }
       defer_processing_ = false;

--- a/include/boost/sml/back/transitions.hpp
+++ b/include/boost/sml/back/transitions.hpp
@@ -72,6 +72,7 @@ struct transitions<aux::false_type> {
   }
 };
 
+/// @brief Event executor on a sub state machine with transition in parent state machine.
 template <class TSM, class T, class... Ts>
 struct transitions_sub<sm<TSM>, T, Ts...> {
   template <class TEvent, class SM, class TDeps, class TSubs>
@@ -103,11 +104,19 @@ struct transitions_sub<sm<TSM>, T, Ts...> {
   }
 };
 
+/// @brief Event executor on a sub state machine without transition in parent state machine.
 template <class TSM>
 struct transitions_sub<sm<TSM>> {
   template <class TEvent, class SM, class TDeps, class TSubs>
   static bool execute(const TEvent& event, SM&, TDeps& deps, TSubs& subs, typename SM::state_t&) {
-    return sub_sm<sm_impl<TSM>>::get(&subs).template process_event<TEvent>(event, deps, subs);
+    return sub_sm<sm_impl<TSM>>::get(&subs).process_event(event, deps, subs);
+  }
+
+  template <class, class SM, class TDeps, class TSubs>
+  static bool execute(const anonymous&, SM&, TDeps&, TSubs&, typename SM::state_t&) {
+    // Do not propagate anonymous events to sub state machine
+    // Anonymous events will be generated inside sub-statemachine by initial process_event.
+    return false;
   }
 };
 

--- a/include/boost/sml/front/transition.hpp
+++ b/include/boost/sml/front/transition.hpp
@@ -272,16 +272,6 @@ void update_current_state(SM &, TDeps &deps, TSubs &subs, typename SM::state_t &
                                             typename back::sm_impl<T>::history_states_t{});
 }
 
-template <class TDeps, class TSubs, class TDstState>
-void process_internal_transitions(TDeps &, TSubs &, const TDstState &) {}
-
-template <class TDeps, class TSubs, class T>
-void process_internal_transitions(TDeps &deps, TSubs &subs, const state<back::sm<T>> &) {
-  auto &sm = back::sub_sm<back::sm_impl<T>>::get(&subs);
-  while (sm.process_internal_events(back::anonymous{}, deps, subs)) {
-  }
-}
-
 template <class S1, class S2, class E, class G, class A>
 struct transition<state<S1>, state<S2>, front::event<E>, G, A> {
   static constexpr auto initial = state<S2>::initial;
@@ -305,7 +295,6 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, A> {
                            state<dst_state>{});
       call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
       sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
-      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -318,7 +307,6 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, A> {
                            aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                            state<dst_state>{});
       call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
-      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -377,7 +365,6 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, A> {
                          state<dst_state>{});
     call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
     sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
-    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
 
@@ -387,7 +374,6 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, A> {
                          aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                          state<dst_state>{});
     call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
-    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
 
@@ -439,7 +425,6 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, none> {
                            aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                            state<dst_state>{});
       sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
-      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -451,7 +436,6 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, none> {
       update_current_state(sm, deps, subs, current_state,
                            aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                            state<dst_state>{});
-      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -503,7 +487,6 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, none> {
                          aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                          state<dst_state>{});
     sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
-    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
 
@@ -512,7 +495,6 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, none> {
     update_current_state(sm, deps, subs, current_state,
                          aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                          state<dst_state>{});
-    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
 

--- a/test/ft/actions_process_n_defer.cpp
+++ b/test/ft/actions_process_n_defer.cpp
@@ -1,6 +1,8 @@
 #include <boost/sml.hpp>
 #include <deque>
+#include <iostream>
 #include <queue>
+#include <string>
 
 namespace sml = boost::sml;
 
@@ -60,8 +62,48 @@ test mix_process_n_defer = [] {
       // clang-format on
     }
   };  // internal, defer, process, defer, internal, process, internal
-
   sml::sm<c, sml::process_queue<std::queue>, sml::defer_queue<std::deque>> sm{};
   sm.process_event(e1{});
   expect(sm.is(sml::X));
+};
+
+test process_n_defer_again = [] {
+  struct sub {
+    auto operator()() {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+        * s2 + event<e1> / defer
+        , s2 + event<e3> / defer
+        , s2 + event<e2> = s3
+        , s3 + on_entry<_> / [](std::string & calls){calls+="|s3_entry";}
+        , s3 + event<e1> / [](std::string & calls){calls+="|e1";}
+      );
+      // clang-format on
+    }
+  };
+
+  struct c {
+    auto operator()() {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+        * s1 = state<sub>
+        // Check that deferred events are only propagated inside sub state machine.
+        , state<sub> + event<e3> / [](std::string & calls){calls+="|e3";}
+      );
+      // clang-format on
+    }
+  };
+
+  std::string calls;
+  sml::sm<c, sml::process_queue<std::queue>, sml::defer_queue<std::deque>> sm{calls};
+  sm.process_event(e1{});
+  sm.process_event(e1{});
+  sm.process_event(e1{});
+  sm.process_event(e3{});
+  expect(calls == "");
+  sm.process_event(e2{});
+  std::cout << calls << "\n";
+  expect(calls == "|s3_entry|e1|e1|e1");
 };

--- a/test/ft/policies_logging.cpp
+++ b/test/ft/policies_logging.cpp
@@ -180,13 +180,11 @@ test log_sub_sm = [] {
   // clang-format off
   std::vector<std::string> messages_expected = {
      "[c_log_sub_sm] e1"
-   , "[sub] e1"
    , "[c_log_sub_sm] sub(a) -> sub(b)"
    , "[c_log_sub_sm] e2"
    , "[sub] e2"
    , "[sub] idle -> terminate"
    , "[c_log_sub_sm] e3"
-   , "[sub] e3"
    , "[c_log_sub_sm] e3[guard]: true"
    , "[c_log_sub_sm] sub(b) -> terminate"
    , "[c_log_sub_sm] / action"
@@ -220,13 +218,11 @@ test log_sub_sm_mix = [] {
   // clang-format off
   std::vector<std::string> messages_expected = {
      "[c_log_sub_sm_mix] e1"
-   , "[sub] e1"
    , "[c_log_sub_sm_mix] sub(a) -> sub"
    , "[c_log_sub_sm_mix] e2"
    , "[sub] e2"
    , "[sub] idle -> terminate"
    , "[c_log_sub_sm_mix] e3"
-   , "[sub] e3"
    , "[c_log_sub_sm_mix] e3[guard]: true"
    , "[c_log_sub_sm_mix] sub -> terminate"
    , "[c_log_sub_sm_mix] / action"


### PR DESCRIPTION
State machine was processing anonymous events exponentially based on state machine depth.

The following diagram:
``` 
state root {
state substate {
[*] -> subsubstate1
subsubstate1 -> subsubstate2: [guard]
}
[*] -> substate
}
```
Would cause `guard` to be processed 9 times since `subsubstate` has depth 3.
For depth 4 : guard would be processed 27 times, etc.

This is due to the fact that `process_event(anonymous{})` trigger 3 processing of anonymous event and propagate this event to the substate that in turn call  `process_event(anonymous{})` that trigger 3 processing of anonymous event for each parent call.

This quickly becomes a real problem if `guard` is in the last state of a deep state machine.

I had the case where each event processing took 2 secondes because our guard was processed more that 2 thousand times. 