### PR TITLE
Include GCC 10 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,11 @@ matrix:
     env: CXX=g++-9 CXXSTD=c++1z MEMCHECK=VALGRIND
     addons: { apt: { packages: ["g++-9", "libstdc++-9-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
+  - os: linux
+    dist: bionic
+    env: CXX=g++-10 CXXSTD=c++17 MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["g++-10", "libstdc++-10-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
   - os: osx
     osx_image: xcode7.3
     env: CXX=clang++


### PR DESCRIPTION
Unfortunately, GCC 10 is not published for trusty, thus it was necessary to upgrade the used distro to bionic for the GCC 10 build job.

**Warning:** GCC 10 job currently fails because of unfullfillled test expectations

```
test/ft/sizeof.cpp: In lambda function:
test/ft/sizeof.cpp:19:21: error: static assertion failed: fail
   19 |     static_expect(0 == sizeof(t));
./test/common/test.hpp:14:43: note: in definition of macro ‘static_expect’
   14 | #define static_expect(...) static_assert((__VA_ARGS__), "fail")
      |                                           ^~~~~~~~~~~
```