### PR TITLE
:new: [core] Support for member-function like guards/actions

### DIFF
--- a/example/actions_guards.cpp
+++ b/example/actions_guards.cpp
@@ -14,29 +14,6 @@
 namespace sml = boost::sml;
 
 namespace {
-template <class R, class... Ts>
-auto call_impl(R (*f)(Ts...)) {
-  return [f](Ts... args) { return f(args...); };
-}
-template <class T, class R, class... Ts>
-auto call_impl(T* self, R (T::*f)(Ts...)) {
-  return [self, f](Ts... args) { return (self->*f)(args...); };
-}
-template <class T, class R, class... Ts>
-auto call_impl(const T* self, R (T::*f)(Ts...) const) {
-  return [self, f](Ts... args) { return (self->*f)(args...); };
-}
-template <class T, class R, class... Ts>
-auto call_impl(const T* self, R (T::*f)(Ts...)) {
-  return [self, f](Ts... args) { return (self->*f)(args...); };
-}
-/**
- * Simple wrapper to call free/member functions
- * @param args function, [optional] this
- * @return function(args...)
- */
-auto call = [](auto... args) { return call_impl(args...); };
-//->
 
 struct e1 {};
 struct e2 {};
@@ -44,44 +21,48 @@ struct e3 {};
 struct e4 {};
 struct e5 {};
 
-auto guard1 = [] {
-  std::cout << "guard1" << std::endl;
-  return true;
-};
-
-auto guard2 = [](int i) {
-  assert(42 == i);
-  std::cout << "guard2" << std::endl;
-  return false;
-};
-
-bool guard3(int i) {
-  assert(42 == i);
-  std::cout << "guard3" << std::endl;
-  return true;
-}
-
-auto action1 = [](auto e) { std::cout << "action1: " << typeid(e).name() << std::endl; };
-struct action2 {
-  void operator()(int i) {
-    assert(42 == i);
-    std::cout << "action2" << std::endl;
-  }
-};
-
 struct actions_guards {
-  auto operator()() noexcept {
+  using self = actions_guards;
+
+  auto operator()() {
     using namespace sml;
+
+    auto guard1 = [] {
+      std::cout << "guard1" << std::endl;
+      return true;
+    };
+
+    auto guard2 = [](int i) {
+      assert(42 == i);
+      std::cout << "guard2" << std::endl;
+      return false;
+    };
+
+    auto action1 = [](auto e) { std::cout << "action1: " << typeid(e).name() << std::endl; };
+
+    struct action2 {
+      void operator()(int i) {
+        assert(42 == i);
+        std::cout << "action2" << std::endl;
+      }
+    };
+
     // clang-format off
     return make_transition_table(
        *"idle"_s + event<e1> = "s1"_s
       , "s1"_s + event<e2> [ guard1 ] / action1 = "s2"_s
       , "s2"_s + event<e3> [ guard1 && ![] { return false;} ] / (action1, action2{}) = "s3"_s
       , "s3"_s + event<e4> [ !guard1 || guard2 ] / (action1, [] { std::cout << "action3" << std::endl; }) = "s4"_s
-      , "s3"_s + event<e4> [ guard1 ] / ([] { std::cout << "action4" << std::endl; }, [this] { action4(); }) = "s5"_s
-      , "s5"_s + event<e5> [ call(guard3) || guard2 ] / call(this, &actions_guards::action5) = X
+      , "s3"_s + event<e4> [ guard1 ] / ([] { std::cout << "action4" << std::endl; }, [this] { action4(); } ) = "s5"_s
+      , "s5"_s + event<e5> [ &self::guard3 ] / &self::action5 = X
     );
     // clang-format on
+  }
+
+  bool guard3(int i) const {
+    assert(42 == i);
+    std::cout << "guard3" << std::endl;
+    return true;
   }
 
   void action4() const { std::cout << "action4" << std::endl; }
@@ -94,7 +75,8 @@ struct actions_guards {
 }  // namespace
 
 int main() {
-  sml::sm<actions_guards> sm{42};
+  actions_guards ag{};
+  sml::sm<actions_guards> sm{ag, 42};
   sm.process_event(e1{});
   sm.process_event(e2{});
   sm.process_event(e3{});

--- a/include/boost/sml/aux_/utility.hpp
+++ b/include/boost/sml/aux_/utility.hpp
@@ -278,6 +278,24 @@ struct zero_wrapper : TExpr {
   const TExpr &get() const { return *this; }
 };
 
+template <class R, class TBase, class... TArgs>
+struct zero_wrapper<R (TBase::*)(TArgs...)> {
+  explicit zero_wrapper(R (TBase::*ptr)(TArgs...)) : ptr{ptr} {}
+  auto operator()(TBase &self, TArgs... args) { return (self.*ptr)(args...); }
+
+ private:
+  R (TBase::*ptr)(TArgs...){};
+};
+
+template <class R, class TBase, class... TArgs>
+struct zero_wrapper<R (TBase::*)(TArgs...) const> {
+  explicit zero_wrapper(R (TBase::*ptr)(TArgs...) const) : ptr{ptr} {}
+  auto operator()(TBase &self, TArgs... args) { return (self.*ptr)(args...); }
+
+ private:
+  R (TBase::*ptr)(TArgs...) const {};
+};
+
 template <class, class>
 struct zero_wrapper_impl;
 

--- a/include/boost/sml/concepts/callable.hpp
+++ b/include/boost/sml/concepts/callable.hpp
@@ -25,6 +25,12 @@ template <class, class T>
 struct callable
     : decltype(test_callable<aux::inherit<aux::conditional_t<__is_class(T), T, aux::none_type>, callable_fallback>>(0)) {};
 
+template <class T, class R, class TBase, class... TArgs>
+struct callable<T, R (TBase::*)(TArgs...)> : aux::true_type {};
+
+template <class T, class R, class TBase, class... TArgs>
+struct callable<T, R (TBase::*)(TArgs...) const> : aux::true_type {};
+
 }  // namespace concepts
 
 #endif

--- a/test/ft/transition_table.cpp
+++ b/test/ft/transition_table.cpp
@@ -96,6 +96,30 @@ test uml_notation = [] {
   expect(sm.is(sml::X));
 };
 
+test member_functions = [] {
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *idle + event<e1> [ &c::guard ] / &c::action = X
+      );
+      // clang-format on
+    }
+
+    auto guard() const -> bool { return true; }
+    void action() { action_ = true; }
+    bool action_{};
+  };
+
+  c c_{};
+  sml::sm<c> sm{c_};
+  expect(!c_.action_);
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+  expect(c_.action_);
+};
+
 struct c_guard {
   template <class T>
   bool operator()(const T &) const noexcept {


### PR DESCRIPTION
Problem:
- Only lambda-expression like guards/actions are supported.

Solution:
- Add support for member-function like guards/actions using
 `&type::member_function` syntax.