### PR TITLE
:books: [doc] Fix workshop link

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -487,7 +487,7 @@ sm.process_event(my_event{}); // will call my_logger appropriately
 
 ---
 
-## Workshop
+## [Workshop](https://boost-ext.github.io/sml/embo-2018)
 
-<iframe style="width: 100%; height: 600px;" src="http://boost-ext.github.io/sml/embo-2018/#/" />
+<iframe style="width: 100%; height: 600px;" src="https://boost-ext.github.io/sml/embo-2018" />
 


### PR DESCRIPTION
Problem:
- Link to the workshop is broken.

Solution:
- Update it using `https`.