### PR TITLE
Gco/non trivial event missed processing

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -216,7 +216,7 @@ struct remove_reference<T &&> {
 };
 template <class T>
 using remove_reference_t = typename remove_reference<T>::type;
-}
+}  // namespace aux
 namespace aux {
 using swallow = int[];
 template <int...>
@@ -480,7 +480,7 @@ auto get_type_name(const char *ptr, index_sequence<Ns...>) {
   static const char str[] = {ptr[N + Ns]..., 0};
   return str;
 }
-}
+}  // namespace detail
 template <class T>
 const char *get_type_name() {
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -525,7 +525,7 @@ struct string<T> {
   }
   static auto c_str_impl(...) { return get_type_name<T>(); }
 };
-}
+}  // namespace aux
 namespace back {
 namespace policies {
 struct defer_queue_policy__ {};
@@ -535,8 +535,8 @@ struct defer_queue : aux::pair<back::policies::defer_queue_policy__, defer_queue
   using rebind = T<U>;
   using flag = bool;
 };
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 template <class... Ts>
 class queue_event {
@@ -627,7 +627,7 @@ struct deque_handler : queue_event_call<TEvents>... {
   }
   void *deque_{};
 };
-}
+}  // namespace back
 namespace back {
 struct _ {};
 struct initial {};
@@ -709,7 +709,7 @@ template <class... TEvents>
 struct defer : deque_handler<TEvents...> {
   using deque_handler<TEvents...>::deque_handler;
 };
-}
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -832,7 +832,7 @@ template <class T, class... Ts>
 struct convert_to_sm<T, aux::type_list<Ts...>> {
   using type = aux::type_list<sm_impl<T>, sm_impl<typename T::template rebind<Ts>>...>;
 };
-}
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -919,7 +919,7 @@ struct transitions_sub<sm<TSM>> {
     return false;
   }
 };
-}
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -1011,33 +1011,38 @@ struct get_state_mapping<sm<T>, TMappings, TUnexpected> {
 };
 template <class T, class TMappings, class TUnexpected>
 using get_state_mapping_t = typename get_state_mapping<T, TMappings, TUnexpected>::type;
-template <class>
+template <class...>
 transitions<aux::true_type> get_event_mapping_impl(...);
 template <class T, class TMappings>
 TMappings get_event_mapping_impl(event_mappings<T, TMappings> *);
-template <class T, class... T1Mappings, class... T2Mappings>
-unique_mappings_t<T1Mappings..., T2Mappings...> get_event_mapping_impl(event_mappings<T, aux::inherit<T1Mappings...>> *,
-                                                                       event_mappings<_, aux::inherit<T2Mappings...>> *);
+template <class T1, class T2, class... T1Mappings, class... T2Mappings>
+unique_mappings_t<T1Mappings..., T2Mappings...> get_event_mapping_impl(event_mappings<T1, aux::inherit<T1Mappings...>> *,
+                                                                       event_mappings<T2, aux::inherit<T2Mappings...>> *);
+template <class E, class _, class TMappings>
+using with_default_event_mapping_t = typename aux::conditional<
+    aux::is_same<transitions<aux::true_type>, decltype(get_event_mapping_impl<_>((TMappings *)0))>::value,
+    decltype(get_event_mapping_impl<E>((TMappings *)0)),
+    typename aux::conditional<
+        aux::is_same<transitions<aux::true_type>, decltype(get_event_mapping_impl<E>((TMappings *)0))>::value,
+        decltype(get_event_mapping_impl<_>((TMappings *)0)),
+        decltype(get_event_mapping_impl<E, _>((TMappings *)0, (TMappings *)0))>::type>::type;
 template <class T, class TMappings>
-struct get_event_mapping_impl_helper
-    : aux::conditional<aux::is_same<transitions<aux::true_type>, decltype(get_event_mapping_impl<_>((TMappings *)0))>::value,
-                       decltype(get_event_mapping_impl<T>((TMappings *)0)),
-                       decltype(get_event_mapping_impl<T>((TMappings *)0, (TMappings *)0))>::type {};
+struct get_event_mapping_impl_helper : with_default_event_mapping_t<T, _, TMappings> {};
 template <class T, class TMappings>
 struct get_event_mapping_impl_helper<exception<T>, TMappings> : decltype(get_event_mapping_impl<exception<T>>((TMappings *)0)) {
 };
-template <class T1, class T2, class TMappings>
-struct get_event_mapping_impl_helper<unexpected_event<T1, T2>, TMappings>
-    : decltype(get_event_mapping_impl<unexpected_event<T1, T2>>((TMappings *)0)) {};
-template <class T1, class T2, class TMappings>
-struct get_event_mapping_impl_helper<on_entry<T1, T2>, TMappings>
-    : decltype(get_event_mapping_impl<on_entry<T1, T2>>((TMappings *)0)) {};
-template <class T1, class T2, class TMappings>
-struct get_event_mapping_impl_helper<on_exit<T1, T2>, TMappings>
-    : decltype(get_event_mapping_impl<on_exit<T1, T2>>((TMappings *)0)) {};
+template <class E, class _, class TMappings>
+struct get_event_mapping_impl_helper<unexpected_event<_, E>, TMappings>
+    : with_default_event_mapping_t<unexpected_event<_, E>, unexpected_event<_, _>, TMappings> {};
+template <class E, class _, class TMappings>
+struct get_event_mapping_impl_helper<on_entry<_, E>, TMappings>
+    : with_default_event_mapping_t<on_entry<_, E>, on_entry<_, _>, TMappings> {};
+template <class E, class _, class TMappings>
+struct get_event_mapping_impl_helper<on_exit<_, E>, TMappings>
+    : with_default_event_mapping_t<on_exit<_, E>, on_exit<_, _>, TMappings> {};
 template <class T, class TMappings>
 using get_event_mapping_t = get_event_mapping_impl_helper<T, TMappings>;
-}
+}  // namespace back
 namespace back {
 namespace policies {
 struct dispatch_policy__ {};
@@ -1112,8 +1117,8 @@ struct fold_expr {
   }
 };
 #endif
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -1180,8 +1185,8 @@ void log_guard(const aux::type<TLogger> &, TDeps &deps, const aux::zero_wrapper<
                bool result) {
   return static_cast<aux::pool_type<TLogger &> &>(deps).value.template log_guard<SM>(guard.get(), event, result);
 }
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 namespace policies {
 struct process_queue_policy__ {};
@@ -1190,14 +1195,14 @@ struct process_queue : aux::pair<back::policies::process_queue_policy__, process
   template <class U>
   using rebind = T<U>;
 };
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 namespace policies {
 struct testing_policy__ {};
 struct testing : aux::pair<testing_policy__, testing> {};
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 namespace policies {
 struct thread_safety_policy__ {
@@ -1217,8 +1222,8 @@ struct thread_safe : aux::pair<thread_safety_policy__, thread_safe<TLock>> {
   }
   TLock lock;
 };
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 struct no_policy : policies::thread_safety_policy__ {
   using type = no_policy;
@@ -1257,7 +1262,7 @@ struct sm_policy {
   template <class T>
   using rebind = typename rebind_impl<T, TPolicies...>::type;
 };
-}
+}  // namespace back
 namespace concepts {
 struct callable_fallback {
   void operator()();
@@ -1273,7 +1278,7 @@ template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...)> : aux::true_type {};
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const> : aux::true_type {};
-}
+}  // namespace concepts
 namespace concepts {
 template <class T>
 decltype(aux::declval<T>().operator()()) composable_impl(int);
@@ -1281,7 +1286,7 @@ template <class>
 void composable_impl(...);
 template <class T>
 struct composable : aux::is<aux::pool, decltype(composable_impl<T>(0))> {};
-}
+}  // namespace concepts
 #if !defined(BOOST_SML_DISABLE_EXCEPTIONS)
 #if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
 #define BOOST_SML_DISABLE_EXCEPTIONS true
@@ -1427,12 +1432,12 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   bool process_internal_event(const TEvent &event, TDeps &deps, TSubs &subs, state_t &current_state) {
     policies::log_process_event<sm_t>(aux::type<logger_t>{}, deps, event);
 #if BOOST_SML_DISABLE_EXCEPTIONS
-    return process_event_impl<get_event_mapping_t<get_mapped_t<TEvent>, mappings>>(event, deps, subs, states_t{}, current_state)
+    return process_event_impl<get_event_mapping_t<get_mapped_t<TEvent>, mappings>>(event, deps, subs, states_t{},
+                                                                                   current_state);
 #else
     return process_event_noexcept<get_event_mapping_t<get_mapped_t<TEvent>, mappings>>(event, deps, subs, current_state,
-                                                                                       has_exceptions{})
+                                                                                       has_exceptions{});
 #endif
-           || process_internal_generic_event(event, deps, subs, current_state);
   }
   template <class TMappings, class TEvent, class TDeps, class TSubs, class... TStates>
   bool process_event_impl(const TEvent &event, TDeps &deps, TSubs &subs, const aux::type_list<TStates...> &states,
@@ -1738,7 +1743,7 @@ class sm {
   deps_t deps_;
   sub_sms_t sub_sms_;
 };
-}
+}  // namespace back
 namespace front {
 struct operator_base {};
 struct action_base {};
@@ -1970,7 +1975,7 @@ class not_ : operator_base {
  private:
   T g;
 };
-}
+}  // namespace front
 template <class T, __BOOST_SML_REQUIRES(concepts::callable<bool, T>::value)>
 auto operator!(const T &t) {
   return front::not_<aux::zero_wrapper<T>>(aux::zero_wrapper<T>{t});
@@ -1999,8 +2004,8 @@ struct defer : action_base {
     }
   }
 };
-}
-}
+}  // namespace actions
+}  // namespace front
 using testing = back::policies::testing;
 template <class T>
 using logger = back::policies::logger<T>;
@@ -2026,7 +2031,7 @@ auto transitional_impl(T &&t) -> aux::always<typename T::dst_state, typename T::
                                              decltype(T::initial), decltype(T::history)>;
 template <class T>
 struct transitional : decltype(transitional_impl(aux::declval<T>())) {};
-}
+}  // namespace concepts
 namespace front {
 namespace actions {
 struct process {
@@ -2047,8 +2052,8 @@ struct process {
     return process_impl<TEvent>{event};
   }
 };
-}
-}
+}  // namespace actions
+}  // namespace front
 namespace front {
 template <class, class>
 struct transition_eg;
@@ -2066,7 +2071,7 @@ struct event {
   }
   auto operator()() const { return TEvent{}; }
 };
-}
+}  // namespace front
 namespace front {
 struct initial_state {};
 struct history_state {};
@@ -2159,7 +2164,7 @@ struct state_sm<T, aux::enable_if_t<concepts::composable<T>::value>> {
   using type = state<back::sm<back::sm_policy<T>>>;
 };
 #endif
-}
+}  // namespace front
 namespace front {
 struct internal {};
 template <class, class>
@@ -2593,7 +2598,7 @@ struct transition<state<internal>, state<S2>, front::event<E>, always, none> {
   }
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
 };
-}
+}  // namespace front
 using _ = back::_;
 #if !(defined(_MSC_VER) && !defined(__clang__))
 template <class TEvent>
@@ -2641,7 +2646,7 @@ constexpr auto operator""_e() {
   return event<aux::string<T, Chrs...>>;
 }
 #endif
-}
+}  // namespace literals
 __BOOST_SML_UNUSED static front::state<back::terminate_state> X;
 __BOOST_SML_UNUSED static front::history_state H;
 __BOOST_SML_UNUSED static front::actions::defer defer;

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -182,12 +182,12 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   bool process_internal_event(const TEvent &event, TDeps &deps, TSubs &subs, state_t &current_state) {
     policies::log_process_event<sm_t>(aux::type<logger_t>{}, deps, event);
 #if BOOST_SML_DISABLE_EXCEPTIONS  // __pph__
-    return process_event_impl<get_event_mapping_t<get_mapped_t<TEvent>, mappings>>(event, deps, subs, states_t{}, current_state)
+    return process_event_impl<get_event_mapping_t<get_mapped_t<TEvent>, mappings>>(event, deps, subs, states_t{},
+                                                                                   current_state);
 #else   // __pph__
     return process_event_noexcept<get_event_mapping_t<get_mapped_t<TEvent>, mappings>>(event, deps, subs, current_state,
-                                                                                       has_exceptions{})
+                                                                                       has_exceptions{});
 #endif  // __pph__
-           || process_internal_generic_event(event, deps, subs, current_state);
   }
 
   template <class TMappings, class TEvent, class TDeps, class TSubs, class... TStates>


### PR DESCRIPTION
Problem:
- Non trivial on_exit/on_entry can hide on_entry<_>/on_exit<_> in parents state machine.
This is due to a dual pass done to process non trivial event:
- First we process non trivial event, then we process generic event if it failed.
PR https://github.com/boost-ext/sml/pull/370 amplify this bug: 
on_exit are now processed like on_entry and return true if any child state handle the non trivial event, this imply that generic event will not be processed for parent states.

Solution:
- Fix the problem by doing a single pass of processing that will trigger the correct event (either mapped or generic).
This is done by updating mapping generation to take into account that on_entry/on_exit/unexpected_event have a specific generic event case. 


Reviewers:
@krzysztof-jusiak 