### PR TITLE
Make callable concept recognize noexcept member functions

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1273,10 +1273,6 @@ template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...)> : aux::true_type {};
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const> : aux::true_type {};
-template <class T, class R, class TBase, class... TArgs>
-struct callable<T, R (TBase::*)(TArgs...) noexcept> : aux::true_type {};
-template <class T, class R, class TBase, class... TArgs>
-struct callable<T, R (TBase::*)(TArgs...) const noexcept> : aux::true_type {};
 }  // namespace concepts
 namespace concepts {
 template <class T>

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -216,7 +216,7 @@ struct remove_reference<T &&> {
 };
 template <class T>
 using remove_reference_t = typename remove_reference<T>::type;
-}
+}  // namespace aux
 namespace aux {
 using swallow = int[];
 template <int...>
@@ -480,7 +480,7 @@ auto get_type_name(const char *ptr, index_sequence<Ns...>) {
   static const char str[] = {ptr[N + Ns]..., 0};
   return str;
 }
-}
+}  // namespace detail
 template <class T>
 const char *get_type_name() {
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -525,7 +525,7 @@ struct string<T> {
   }
   static auto c_str_impl(...) { return get_type_name<T>(); }
 };
-}
+}  // namespace aux
 namespace back {
 namespace policies {
 struct defer_queue_policy__ {};
@@ -535,8 +535,8 @@ struct defer_queue : aux::pair<back::policies::defer_queue_policy__, defer_queue
   using rebind = T<U>;
   using flag = bool;
 };
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 template <class... Ts>
 class queue_event {
@@ -627,7 +627,7 @@ struct deque_handler : queue_event_call<TEvents>... {
   }
   void *deque_{};
 };
-}
+}  // namespace back
 namespace back {
 struct _ {};
 struct initial {};
@@ -709,7 +709,7 @@ template <class... TEvents>
 struct defer : deque_handler<TEvents...> {
   using deque_handler<TEvents...>::deque_handler;
 };
-}
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -832,7 +832,7 @@ template <class T, class... Ts>
 struct convert_to_sm<T, aux::type_list<Ts...>> {
   using type = aux::type_list<sm_impl<T>, sm_impl<typename T::template rebind<Ts>>...>;
 };
-}
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -919,7 +919,7 @@ struct transitions_sub<sm<TSM>> {
     return false;
   }
 };
-}
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -1037,7 +1037,7 @@ struct get_event_mapping_impl_helper<on_exit<T1, T2>, TMappings>
     : decltype(get_event_mapping_impl<on_exit<T1, T2>>((TMappings *)0)) {};
 template <class T, class TMappings>
 using get_event_mapping_t = get_event_mapping_impl_helper<T, TMappings>;
-}
+}  // namespace back
 namespace back {
 namespace policies {
 struct dispatch_policy__ {};
@@ -1112,8 +1112,8 @@ struct fold_expr {
   }
 };
 #endif
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 template <class>
 class sm;
@@ -1180,8 +1180,8 @@ void log_guard(const aux::type<TLogger> &, TDeps &deps, const aux::zero_wrapper<
                bool result) {
   return static_cast<aux::pool_type<TLogger &> &>(deps).value.template log_guard<SM>(guard.get(), event, result);
 }
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 namespace policies {
 struct process_queue_policy__ {};
@@ -1190,14 +1190,14 @@ struct process_queue : aux::pair<back::policies::process_queue_policy__, process
   template <class U>
   using rebind = T<U>;
 };
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 namespace policies {
 struct testing_policy__ {};
 struct testing : aux::pair<testing_policy__, testing> {};
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 namespace policies {
 struct thread_safety_policy__ {
@@ -1217,8 +1217,8 @@ struct thread_safe : aux::pair<thread_safety_policy__, thread_safe<TLock>> {
   }
   TLock lock;
 };
-}
-}
+}  // namespace policies
+}  // namespace back
 namespace back {
 struct no_policy : policies::thread_safety_policy__ {
   using type = no_policy;
@@ -1257,7 +1257,7 @@ struct sm_policy {
   template <class T>
   using rebind = typename rebind_impl<T, TPolicies...>::type;
 };
-}
+}  // namespace back
 namespace concepts {
 struct callable_fallback {
   void operator()();
@@ -1273,7 +1273,11 @@ template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...)> : aux::true_type {};
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const> : aux::true_type {};
-}
+template <class T, class R, class TBase, class... TArgs>
+struct callable<T, R (TBase::*)(TArgs...) noexcept> : aux::true_type {};
+template <class T, class R, class TBase, class... TArgs>
+struct callable<T, R (TBase::*)(TArgs...) const noexcept> : aux::true_type {};
+}  // namespace concepts
 namespace concepts {
 template <class T>
 decltype(aux::declval<T>().operator()()) composable_impl(int);
@@ -1281,7 +1285,7 @@ template <class>
 void composable_impl(...);
 template <class T>
 struct composable : aux::is<aux::pool, decltype(composable_impl<T>(0))> {};
-}
+}  // namespace concepts
 #if !defined(BOOST_SML_DISABLE_EXCEPTIONS)
 #if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
 #define BOOST_SML_DISABLE_EXCEPTIONS true
@@ -1738,7 +1742,7 @@ class sm {
   deps_t deps_;
   sub_sms_t sub_sms_;
 };
-}
+}  // namespace back
 namespace front {
 struct operator_base {};
 struct action_base {};
@@ -1970,7 +1974,7 @@ class not_ : operator_base {
  private:
   T g;
 };
-}
+}  // namespace front
 template <class T, __BOOST_SML_REQUIRES(concepts::callable<bool, T>::value)>
 auto operator!(const T &t) {
   return front::not_<aux::zero_wrapper<T>>(aux::zero_wrapper<T>{t});
@@ -1999,8 +2003,8 @@ struct defer : action_base {
     }
   }
 };
-}
-}
+}  // namespace actions
+}  // namespace front
 using testing = back::policies::testing;
 template <class T>
 using logger = back::policies::logger<T>;
@@ -2026,7 +2030,7 @@ auto transitional_impl(T &&t) -> aux::always<typename T::dst_state, typename T::
                                              decltype(T::initial), decltype(T::history)>;
 template <class T>
 struct transitional : decltype(transitional_impl(aux::declval<T>())) {};
-}
+}  // namespace concepts
 namespace front {
 namespace actions {
 struct process {
@@ -2047,8 +2051,8 @@ struct process {
     return process_impl<TEvent>{event};
   }
 };
-}
-}
+}  // namespace actions
+}  // namespace front
 namespace front {
 template <class, class>
 struct transition_eg;
@@ -2066,7 +2070,7 @@ struct event {
   }
   auto operator()() const { return TEvent{}; }
 };
-}
+}  // namespace front
 namespace front {
 struct initial_state {};
 struct history_state {};
@@ -2159,7 +2163,7 @@ struct state_sm<T, aux::enable_if_t<concepts::composable<T>::value>> {
   using type = state<back::sm<back::sm_policy<T>>>;
 };
 #endif
-}
+}  // namespace front
 namespace front {
 struct internal {};
 template <class, class>
@@ -2593,7 +2597,7 @@ struct transition<state<internal>, state<S2>, front::event<E>, always, none> {
   }
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
 };
-}
+}  // namespace front
 using _ = back::_;
 #if !(defined(_MSC_VER) && !defined(__clang__))
 template <class TEvent>
@@ -2641,7 +2645,7 @@ constexpr auto operator""_e() {
   return event<aux::string<T, Chrs...>>;
 }
 #endif
-}
+}  // namespace literals
 __BOOST_SML_UNUSED static front::state<back::terminate_state> X;
 __BOOST_SML_UNUSED static front::history_state H;
 __BOOST_SML_UNUSED static front::actions::defer defer;

--- a/include/boost/sml/concepts/callable.hpp
+++ b/include/boost/sml/concepts/callable.hpp
@@ -31,11 +31,13 @@ struct callable<T, R (TBase::*)(TArgs...)> : aux::true_type {};
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const> : aux::true_type {};
 
+#ifdef __cpp_noexcept_function_type
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) noexcept> : aux::true_type {};
 
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const noexcept> : aux::true_type {};
+#endif
 }  // namespace concepts
 
 #endif

--- a/include/boost/sml/concepts/callable.hpp
+++ b/include/boost/sml/concepts/callable.hpp
@@ -31,6 +31,11 @@ struct callable<T, R (TBase::*)(TArgs...)> : aux::true_type {};
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const> : aux::true_type {};
 
+template <class T, class R, class TBase, class... TArgs>
+struct callable<T, R (TBase::*)(TArgs...) noexcept> : aux::true_type {};
+
+template <class T, class R, class TBase, class... TArgs>
+struct callable<T, R (TBase::*)(TArgs...) const noexcept> : aux::true_type {};
 }  // namespace concepts
 
 #endif

--- a/test/ut/concepts.cpp
+++ b/test/ut/concepts.cpp
@@ -36,6 +36,8 @@ test composable_concept = [] {
   static_expect(composable<c1>::value);
   static_expect(composable<c2>::value);
   static_expect(composable<c3>::value);
+  static_expect(composable<c3>::value);
+  static_expect(composable<c3>::value);
   static_expect(!composable<c0>::value);
   static_expect(!composable<c4>::value);
   static_expect(!composable<c5>::value);
@@ -72,6 +74,16 @@ test callable_concept = [] {
   auto calll2 = [](int) {};
   auto calll3 = [] { return true; };
 
+  struct class0 {
+    void action() {}
+    void const_action() const {}
+    void const_noexcept_action() const noexcept {}
+
+    bool guard() { return true; }
+    bool const_guard() const { return true; }
+    bool const_noexcept_guard() const noexcept { return true; }
+  };
+
   static_expect(!callable<void, call>::value);
   static_expect(callable<void, call1>::value);
   static_expect(callable<void, call2>::value);
@@ -82,6 +94,13 @@ test callable_concept = [] {
   static_expect(callable<void, decltype(calll1)>::value);
   static_expect(callable<void, decltype(calll2)>::value);
   static_expect(callable<bool, decltype(calll3)>::value);
+  static_expect(callable<void, decltype(&class0::action)>::value);
+  static_expect(callable<void, decltype(&class0::const_action)>::value);
+  static_expect(callable<void, decltype(&class0::const_noexcept_action)>::value);
+  static_expect(callable<bool, decltype(&class0::guard)>::value);
+  static_expect(callable<bool, decltype(&class0::const_guard)>::value);
+  static_expect(callable<bool, decltype(&class0::const_noexcept_guard)>::value);
+
   (void)calll1;
   (void)calll2;
   (void)calll3;

--- a/test/ut/concepts.cpp
+++ b/test/ut/concepts.cpp
@@ -74,16 +74,6 @@ test callable_concept = [] {
   auto calll2 = [](int) {};
   auto calll3 = [] { return true; };
 
-  struct class0 {
-    void action() {}
-    void const_action() const {}
-    void const_noexcept_action() const noexcept {}
-
-    bool guard() { return true; }
-    bool const_guard() const { return true; }
-    bool const_noexcept_guard() const noexcept { return true; }
-  };
-
   static_expect(!callable<void, call>::value);
   static_expect(callable<void, call1>::value);
   static_expect(callable<void, call2>::value);
@@ -94,12 +84,24 @@ test callable_concept = [] {
   static_expect(callable<void, decltype(calll1)>::value);
   static_expect(callable<void, decltype(calll2)>::value);
   static_expect(callable<bool, decltype(calll3)>::value);
+
+#ifdef __cpp_noexcept_function_type
+  struct class0 {
+    void action() {}
+    void const_action() const {}
+    void const_noexcept_action() const noexcept {}
+
+    bool guard() { return true; }
+    bool const_guard() const { return true; }
+    bool const_noexcept_guard() const noexcept { return true; }
+  };
   static_expect(callable<void, decltype(&class0::action)>::value);
   static_expect(callable<void, decltype(&class0::const_action)>::value);
   static_expect(callable<void, decltype(&class0::const_noexcept_action)>::value);
   static_expect(callable<bool, decltype(&class0::guard)>::value);
   static_expect(callable<bool, decltype(&class0::const_guard)>::value);
   static_expect(callable<bool, decltype(&class0::const_noexcept_guard)>::value);
+#endif
 
   (void)calll1;
   (void)calll2;


### PR DESCRIPTION
Problem:
- The `callable` concept currently does not recognize `noexcept` member functions

Solution:
- Add template specializations for `noexcept` member functions
