### PR TITLE
:art: [style] Regenerate style and `sml.hpp`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,17 @@ matrix:
 # Style
 #
   - os: linux
-    dist: trusty
-    env: CHECK=ON CLANG_FORMAT=clang-format-4.0 CLANG_TIDY=clang-tidy-4.0
-    addons: { apt: { packages: ["clang-format-4.0", "clang-tidy-4.0", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-4.0"] } }
-
+    dist: xenial
+    env: CHECK=ON CLANG_FORMAT=clang-format-9 CLANG_TIDY=clang-tidy-9
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - sourceline: 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+            key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+        packages:
+          - clang-format-9
+          - clang-tidy-9
 #
 # Build
 #

--- a/example/data.cpp
+++ b/example/data.cpp
@@ -32,13 +32,10 @@ class data {
  public:
   explicit data(const std::string& address) : address{address} {}
 
-  void print(Connected& state) { std::cout << address << ':' << state.id << '\n'; };
-
   auto operator()() {
     using namespace boost::sml;
 
     const auto set = [](const auto& event, Connected& state) { state.id = event.id; };
-
     const auto update = [](Connected& src_state, Interrupted& dst_state) { dst_state.id = src_state.id; };
 
     // clang-format off
@@ -52,6 +49,8 @@ class data {
   }
 
  private:
+  void print(Connected& state) { std::cout << address << ':' << state.id << '\n'; };
+
   std::string address{};  /// shared data between states
 };
 }  // namespace

--- a/example/dispatch_table.cpp
+++ b/example/dispatch_table.cpp
@@ -6,6 +6,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 #include "boost/sml/utility/dispatch_table.hpp"
+
 #include <boost/sml.hpp>
 #include <cassert>
 

--- a/example/sdl2.cpp
+++ b/example/sdl2.cpp
@@ -8,6 +8,7 @@
 #include <boost/sml.hpp>
 #include <cassert>
 #include <iostream>
+
 #include "boost/sml/utility/dispatch_table.hpp"
 
 namespace sml = boost::sml;

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1273,6 +1273,12 @@ template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...)> : aux::true_type {};
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const> : aux::true_type {};
+#if defined(__cpp_noexcept_function_type)
+template <class T, class R, class TBase, class... TArgs>
+struct callable<T, R (TBase::*)(TArgs...) noexcept> : aux::true_type {};
+template <class T, class R, class TBase, class... TArgs>
+struct callable<T, R (TBase::*)(TArgs...) const noexcept> : aux::true_type {};
+#endif
 }  // namespace concepts
 namespace concepts {
 template <class T>

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -102,7 +102,7 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
     auto region = 0;
 #if defined(__cpp_fold_expressions)  // __pph__
     ((current_state_[region++] = aux::get_id<state_t, TStates>((states_ids_t *)0)), ...);
-#else  // __pph__
+#else   // __pph__
     (void)aux::swallow{0, (current_state_[region++] = aux::get_id<state_t, TStates>((states_ids_t *)0), 0)...};
 #endif  // __pph__
   }
@@ -323,7 +323,7 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
 #if BOOST_SML_DISABLE_EXCEPTIONS  // __pph__
     return process_event_impl<get_event_mapping_t<TEvent, mappings>>(event, deps, subs, states_t{},
                                                                      aux::make_index_sequence<regions>{});
-#else  // __pph__
+#else   // __pph__
     return process_event_noexcept<get_event_mapping_t<TEvent, mappings>>(event, deps, subs, has_exceptions{});
 #endif  // __pph__
   }

--- a/include/boost/sml/concepts/callable.hpp
+++ b/include/boost/sml/concepts/callable.hpp
@@ -31,13 +31,13 @@ struct callable<T, R (TBase::*)(TArgs...)> : aux::true_type {};
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const> : aux::true_type {};
 
-#ifdef __cpp_noexcept_function_type
+#if defined(__cpp_noexcept_function_type)  // __pph__
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) noexcept> : aux::true_type {};
 
 template <class T, class R, class TBase, class... TArgs>
 struct callable<T, R (TBase::*)(TArgs...) const noexcept> : aux::true_type {};
-#endif
+#endif  // __pph__
 }  // namespace concepts
 
 #endif

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -76,7 +76,7 @@ constexpr auto operator""_e() {
   return event<aux::string<T, Chrs...>>;
 }
 #endif                                             // __pph__
-}  // literals
+}  // namespace literals
 
 __BOOST_SML_UNUSED static front::state<back::terminate_state> X;
 __BOOST_SML_UNUSED static front::history_state H;

--- a/test/ft/deep_sm.cpp
+++ b/test/ft/deep_sm.cpp
@@ -32,7 +32,8 @@ struct s0 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<struct run_>;
-    return make_transition_table(*idle + event<e0> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e0> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -40,7 +41,8 @@ struct s1 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s0>;
-    return make_transition_table(*idle + event<e1> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e1> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -48,7 +50,8 @@ struct s2 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s1>;
-    return make_transition_table(*idle + event<e2> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e2> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -56,7 +59,8 @@ struct s3 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s2>;
-    return make_transition_table(*idle + event<e3> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e3> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -64,7 +68,8 @@ struct s4 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s3>;
-    return make_transition_table(*idle + event<e4> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e4> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -72,7 +77,8 @@ struct s5 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s4>;
-    return make_transition_table(*idle + event<e5> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e5> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -80,7 +86,8 @@ struct s6 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s5>;
-    return make_transition_table(*idle + event<e6> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e6> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -88,7 +95,8 @@ struct s7 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s6>;
-    return make_transition_table(*idle + event<e7> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e7> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -96,7 +104,8 @@ struct s8 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s7>;
-    return make_transition_table(*idle + event<e8> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e8> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -104,7 +113,8 @@ struct s9 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s8>;
-    return make_transition_table(*idle + event<e9> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e9> = run, run + on_entry<_> / [] {});
   }
 };
 
@@ -112,7 +122,8 @@ struct s10 {
   auto operator()() noexcept {
     auto idle = state<struct idle_>;
     auto run = state<s9>;
-    return make_transition_table(*idle + event<e10> = run, run + on_entry<_> / [] {});
+    return make_transition_table(
+        *idle + event<e10> = run, run + on_entry<_> / [] {});
   }
 };
 

--- a/test/ft/dispatch_table.cpp
+++ b/test/ft/dispatch_table.cpp
@@ -7,6 +7,7 @@
 //
 #if !defined(_MSC_VER)
 #include "boost/sml/utility/dispatch_table.hpp"
+
 #include <boost/sml.hpp>
 #include <string>
 #include <utility>

--- a/test/ut/concepts.cpp
+++ b/test/ut/concepts.cpp
@@ -85,7 +85,7 @@ test callable_concept = [] {
   static_expect(callable<void, decltype(calll2)>::value);
   static_expect(callable<bool, decltype(calll3)>::value);
 
-#ifdef __cpp_noexcept_function_type
+#if defined(__cpp_noexcept_function_type)
   struct class0 {
     void action() {}
     void const_action() const {}


### PR DESCRIPTION
Problem:
- clang-format is out of date and `sml.hpp` is not in sync.

Solution:
- Add `__pph__` to define definition and call `tools/pph.sh` with clang-format.
