### PR TITLE
:new: [core] Support for `CTAD` with `sm`

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -13,7 +13,7 @@ source_group(example)
 
 if (IS_COMPILER_GCC_LIKE)
     add_executable(actions_guards actions_guards.cpp)
-    target_link_libraries(actions_guards PUBLIC sml) 
+    target_link_libraries(actions_guards PUBLIC sml)
     add_test(example_actions_guards actions_guards)
 
     if (IS_COMPILER_GCC_LIKE)
@@ -22,11 +22,8 @@ if (IS_COMPILER_GCC_LIKE)
     endif()
 
     add_example(composite example_composite composite.cpp)
-
     add_example(data example_data data.cpp)
-
     add_example(defer_and_process example_defer_and_process defer_and_process.cpp)
-
     add_example(dependencies example_dependencies dependencies.cpp)
 endif()
 
@@ -53,7 +50,7 @@ if (IS_COMPILER_GCC_LIKE)
     add_example(euml_emulation example_euml_emulation euml_emulation.cpp)
 
     add_executable(events events.cpp)
-    target_link_libraries(events PUBLIC sml) 
+    target_link_libraries(events PUBLIC sml)
     add_test(example_events events)
 
     if (IS_COMPILER_GCC_LIKE)
@@ -68,22 +65,14 @@ endif()
 
 if (IS_COMPILER_GCC_LIKE)
     add_example(history example_history history.cpp)
-
+    add_example(in_place example_in_place in_place.cpp)
     add_example(logging example_logging logging.cpp)
-
     add_example(nested example_nested nested.cpp)
-
     add_example(orthogonal_regions example_orthogonal_regions orthogonal_regions.cpp)
-
     add_example(plant_uml example_plant_uml plant_uml.cpp)
-
     add_example(sdl2 example_sdl2 sdl2.cpp)
-
     add_example(states example_states states.cpp)
-
     add_example(testing example_testing testing.cpp)
-
     add_example(transitions example_transitions transitions.cpp)
-
     add_example(visitor example_visitor visitor.cpp)
 endif()

--- a/example/in_place.cpp
+++ b/example/in_place.cpp
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2016-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <boost/sml.hpp>
+#include <cassert>
+#include <iostream>
+
+int main() {
+#if defined(__cpp_deduction_guides)  // __pph__
+  namespace sml = boost::sml;
+
+  struct start {};
+
+  sml::front::sm sm = [] {
+    using namespace sml;
+    return make_transition_table(*"idle"_s + event<start> / [] { std::cout << "action\n"; } = X);
+  };
+
+  sm.process_event(start{});
+  assert(sm.is(sml::X));
+#endif
+}

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2067,6 +2067,15 @@ using sm = back::sm<back::sm_policy<T__, TPolicies...>>;
 template <class T, class... TPolicies>
 using sm = back::sm<back::sm_policy<T, TPolicies...>>;
 #endif
+#if defined(__cpp_deduction_guides)
+namespace front {
+template <class T, class... TPolicies>
+struct sm : back::sm<back::sm_policy<T, TPolicies...>> {
+  constexpr sm(T t) : back::sm<back::sm_policy<T, TPolicies...>>::sm{t} {}
+  using back::sm<back::sm_policy<T, TPolicies...>>::sm;
+};
+}  // namespace front
+#endif
 namespace concepts {
 aux::false_type transitional_impl(...);
 template <class T>

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -433,13 +433,10 @@ class sm {
   }
 
   sm(aux::init, deps_t &deps) : deps_{deps}, sub_sms_{deps} { aux::get<sm_impl<TSM>>(sub_sms_).start(deps_, sub_sms_); }
-
   sm(const sm &) = default;
-
   sm(sm &&) = default;
 
   sm &operator=(const sm &) = default;
-
   sm &operator=(sm &&) = default;
 
   template <class TEvent, __BOOST_SML_REQUIRES(aux::is_base_of<TEvent, events_ids>::value)>

--- a/include/boost/sml/state_machine.hpp
+++ b/include/boost/sml/state_machine.hpp
@@ -35,4 +35,14 @@ template <class T, class... TPolicies>
 using sm = back::sm<back::sm_policy<T, TPolicies...>>;
 #endif  // __pph__
 
+#if defined(__cpp_deduction_guides)  // __pph__
+namespace front {
+template <class T, class... TPolicies>
+struct sm : back::sm<back::sm_policy<T, TPolicies...>> {
+  constexpr sm(T t) : back::sm<back::sm_policy<T, TPolicies...>>::sm{t} {}
+  using back::sm<back::sm_policy<T, TPolicies...>>::sm;
+};
+}  // namespace front
+#endif  // __pph__
+
 #endif


### PR DESCRIPTION
Problem:
- CTAD can be used to define State Machines in-place.

Solution:
- Use struct instead of alias to support CTAD construction.
- Add example how to use `CTAD` with `sm`

Example:

```
sml::sm sm = [] {
  using namespace sml;
  return make_transition_table(...);
};
```
@