### PR TITLE
:arrow_up: [copyright] Add  missing LICENSE info

### DIFF
--- a/example/actions_guards.cpp
+++ b/example/actions_guards.cpp
@@ -5,7 +5,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-
 #include <boost/sml.hpp>
 #include <cassert>
 #include <iostream>

--- a/test/ft/actions_process_n_defer.cpp
+++ b/test/ft/actions_process_n_defer.cpp
@@ -1,3 +1,10 @@
+//
+// Copyright (c) 2016-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
 #include <boost/sml.hpp>
 #include <deque>
 #include <iostream>


### PR DESCRIPTION
Problem:
- All files are required to have LICENSE info.

Solution:
- Add LICENSE to the top missing files.