### PR TITLE
:new: [data] Allow shared default-constructible types to be either in…

### DIFF
--- a/example/data.cpp
+++ b/example/data.cpp
@@ -56,11 +56,8 @@ class data {
 }  // namespace
 
 int main() {
-  Disconnected ds{};
-  Connected cs{};
-  Interrupted is{};
   data d{std::string{"127.0.0.1"}};
-  sml::sm<data> sm{d, ds, cs, is};
+  sml::sm<data> sm{d, Connected{1}};
   sm.process_event(connect{1024});
   sm.process_event(interrupt{});
   sm.process_event(connect{1025});

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -336,12 +336,26 @@ struct init {};
 struct pool_type_base {
   __BOOST_SML_ZERO_SIZE_ARRAY(byte);
 };
-template <class T>
-struct pool_type : pool_type_base {
-  explicit pool_type(T object) : value{object} {}
+template <class T, class = void>
+struct pool_type_impl : pool_type_base {
+  explicit pool_type_impl(T object) : value{object} {}
   template <class TObject>
-  pool_type(init i, TObject object) : value{i, object} {}
+  pool_type_impl(init i, TObject object) : value{i, object} {}
   T value;
+};
+template <class T>
+struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value>> : pool_type_base {
+  explicit pool_type_impl(T &value) : value{value} {}
+  template <class TObject>
+  explicit pool_type_impl(TObject value) : value_{value}, value{value_} {}
+  template <class TObject>
+  pool_type_impl(const init &i, const TObject &object) : value(i, object) {}
+  T value_{};
+  T &value;
+};
+template <class T>
+struct pool_type : pool_type_impl<T> {
+  using pool_type_impl<T>::pool_type_impl;
 };
 template <class T>
 struct missing_ctor_parameter {

--- a/test/ft/dependencies.cpp
+++ b/test/ft/dependencies.cpp
@@ -37,6 +37,43 @@ test minimal_with_dependency = [] {
   expect(sm.is(idle));
 };
 
+#if !defined(_MSC_VER)
+test default_dependency = [] {
+  struct data {
+    int id{};
+  };
+
+  struct c {
+    auto operator()() {
+      using namespace sml;
+      return make_transition_table(*idle + event<e1>[([](data& d) { return d.id == 42; })] = X);
+    }
+  };
+
+  {
+    sml::sm<c> sm{};
+    expect(sm.is(idle));
+    sm.process_event(e1{});
+    expect(sm.is(idle));
+  }
+
+  {
+    sml::sm<c> sm{data{42}};
+    expect(sm.is(idle));
+    sm.process_event(e1{});
+    expect(sm.is(sml::X));
+  }
+
+  {
+    data d{42};
+    sml::sm<c> sm{d};
+    expect(sm.is(idle));
+    sm.process_event(e1{});
+    expect(sm.is(sml::X));
+  }
+};
+#endif
+
 test dependencies = [] {
   struct c {
     auto operator()() noexcept {


### PR DESCRIPTION
…jected or constructed by the State Machine

Problem:
- All dependencies which are shared have to be injected which is not always desired.

Solution:
- Allow the State Machine to create default-construcitble types if they aren't injected.