### PR TITLE
Update tutorial.md

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -476,8 +476,9 @@ struct my_logger {
   }
 };
 
-sml::sm<logging, sml::logger<my_logger>> sm;
-sm.process_event(my_event{}); // will call my_logger appropriately
+my_logger logger;
+sml::sm<logging, sml::logger<my_logger>> sm{logger};
+sm.process_event(my_event{}); // will call logger appropriately
 ```
 
 ![CPP(BTN)](Run_Logging_Example|https://raw.githubusercontent.com/boost-ext/sml/master/example/logging.cpp)


### PR DESCRIPTION
Fix the example code for the Tutorial/Workshop Chapter 10., Debug it

Problem:
- the example would produce an error at compile time:
boost-sml-src/include/boost/sml.hpp:353:5: Static_assert failed due to requirement 'missing_ctor_parameter<my_logger>::value' "State Machine is missing a constructor parameter! Check out the `missing_ctor_parameter` error to see the missing type."

Solution:
- create an instance of the logger type and pass it as argument to the constructor of sml::sm

Issue: #

Reviewers:
@