### PR TITLE
:bug: :racehorse: Guards should short circuit without `fold expressio…

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1994,8 +1994,8 @@ class and_ : operator_base {
             ...);
 #else
     auto result = true;
-    (void)aux::swallow{0, (result &= call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g),
-                                                                                                       event, sm, deps, subs),
+    (void)aux::swallow{0, (result = result && call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(
+                                                  aux::get_by_id<Ns>(&g), event, sm, deps, subs),
                            0)...};
     return result;
 #endif
@@ -2019,8 +2019,8 @@ class or_ : operator_base {
             ...);
 #else
     auto result = false;
-    (void)aux::swallow{0, (result |= call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g),
-                                                                                                       event, sm, deps, subs),
+    (void)aux::swallow{0, (result = result || call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(
+                                                  aux::get_by_id<Ns>(&g), event, sm, deps, subs),
                            0)...};
     return result;
 #endif

--- a/include/boost/sml/front/operators.hpp
+++ b/include/boost/sml/front/operators.hpp
@@ -220,8 +220,8 @@ class and_ : operator_base {
             ...);
 #else   // __pph__
     auto result = true;
-    (void)aux::swallow{0, (result &= call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g),
-                                                                                                       event, sm, deps, subs),
+    (void)aux::swallow{0, (result = result && call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(
+                                                  aux::get_by_id<Ns>(&g), event, sm, deps, subs),
                            0)...};
     return result;
 #endif  // __pph__
@@ -248,8 +248,8 @@ class or_ : operator_base {
             ...);
 #else   // __pph__
     auto result = false;
-    (void)aux::swallow{0, (result |= call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g),
-                                                                                                       event, sm, deps, subs),
+    (void)aux::swallow{0, (result = result || call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(
+                                                  aux::get_by_id<Ns>(&g), event, sm, deps, subs),
                            0)...};
     return result;
 #endif  // __pph__

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -45,6 +45,9 @@ endif ()
 add_executable(test_history history.cpp)
 add_test(test_history test_history)
 
+add_executable(test_guards guards.cpp)
+add_test(test_guards test_guards)
+
 add_executable(test_orthogonal_regions orthogonal_regions.cpp)
 add_test(test_orthogonal_regions test_orthogonal_regions)
 

--- a/test/ft/guards.cpp
+++ b/test/ft/guards.cpp
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2016-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <boost/sml.hpp>
+
+namespace sml = boost::sml;
+
+struct event1 {};
+
+const auto state1 = sml::state<class state1>;
+const auto state2 = sml::state<class state2>;
+const auto state3 = sml::state<class state2>;
+
+test guards_logic_should_short_circuit = [] {
+  struct c {
+    auto operator()() {
+      using namespace sml;
+      auto guard_true = [this] {
+        ++guard_true_calls;
+        return true;
+      };
+      auto guard_false = [this] {
+        ++guard_false_calls;
+        return false;
+      };
+
+      // clang-format off
+        return make_transition_table(
+         *state1 + event<event1> [ guard_true || guard_true ] = state2,
+          state2 + event<event1> [ guard_false && guard_true ] = state3
+        );
+        // clang-format off
+    }
+
+    int guard_true_calls = 0;
+    int guard_false_calls = 0;
+  };
+
+  sml::sm<c> sm{};
+
+  sm.process_event(event1{});
+  expect(0 == static_cast<const c&>(sm).guard_false_calls);
+  expect(1 == static_cast<const c&>(sm).guard_true_calls);
+  expect(sm.is(state2));
+
+  sm.process_event(event1{});
+  expect(1 == static_cast<const c&>(sm).guard_false_calls);
+  expect(1 == static_cast<const c&>(sm).guard_true_calls);
+  expect(sm.is(state2));
+};


### PR DESCRIPTION
…ns` available, Fix #97

Problem:
- Guards don't short circuit if `fold expressions` aren't available.

Solution:
- Use `result = result && ...` instead of `result &= ...` which does short circut properly.