### PR TITLE
example/plant_uml.cpp - Improve plant uml output to handle entry and …

### DIFF
--- a/example/plant_uml.cpp
+++ b/example/plant_uml.cpp
@@ -26,6 +26,9 @@ struct action {
   void operator()() {}
 } action;
 
+void on_s1_entry() {}
+void on_s2_exit() {}
+
 struct plant_uml {
   auto operator()() const noexcept {
     using namespace sml;
@@ -33,7 +36,9 @@ struct plant_uml {
     return make_transition_table(
        *"idle"_s + event<e1> = "s1"_s
       , "s1"_s + event<e2> [ guard ] / action = "s2"_s
+      , "s1"_s + sml::on_entry<_> / [] { on_s1_entry(); }
       , "s2"_s + event<e3> [ guard ] = "s1"_s
+      , "s2"_s + sml::on_exit<_> / [] { on_s2_exit(); }
       , "s2"_s + event<e4> / action = X
     );
     // clang-format on
@@ -52,18 +57,33 @@ void dump_transition() noexcept {
     std::cout << "[*] --> " << src_state << std::endl;
   }
 
-  std::cout << src_state << " --> " << dst_state;
-
   const auto has_event = !sml::aux::is_same<typename T::event, sml::anonymous>::value;
   const auto has_guard = !sml::aux::is_same<typename T::guard, sml::front::always>::value;
   const auto has_action = !sml::aux::is_same<typename T::action, sml::front::none>::value;
+
+  const auto is_entry = sml::aux::is_same<typename T::event, sml::back::on_entry<sml::_, sml::_>>::value;
+  const auto is_exit = sml::aux::is_same<typename T::event, sml::back::on_exit<sml::_, sml::_>>::value;
+
+  // entry / exit entry
+  if(is_entry || is_exit) {
+    std::cout << src_state;
+  } else { // state to state transition
+    std::cout << src_state << " --> " << dst_state;
+  }
 
   if (has_event || has_guard || has_action) {
     std::cout << " :";
   }
 
   if (has_event) {
-    std::cout << " " << boost::sml::aux::get_type_name<typename T::event>();
+    // handle 'on_entry' and 'on_exit' per plant-uml syntax
+    auto event = std::string(boost::sml::aux::get_type_name<typename T::event>());
+    if(is_entry) {
+      event = "entry";
+    } else if(is_exit) {
+      event = "exit";
+    }
+    std::cout << " " << event;
   }
 
   if (has_guard) {


### PR DESCRIPTION
btw, really like the library!

…exit events, add on_entry<> and on_exit<> to example state machine

Update plant uml output to differentiate between a state transition and an event like 'entry' and 'exit'.

Identify entry and exit classes by strings and replace them with the uml standard naming of 'entry' and 'exit'.



I would like some feedback on the code here. I would really like to do a match based on type, like look for sml::on_entry and sml::on_exit vs. looking for a string match in the string version of the class name. I'm not sure how to do that though and would appreciate feedback.




Problem:
- plant uml output looks a bit janky with the current uml output code when using on_entry and on_exit.
[new_plant_with_incorrect_entry_exit.txt](https://github.com/boost-ext/sml/files/6386583/new_plant_with_incorrect_entry_exit.txt)

![new_plant_with_incorrect_entry_exit](https://user-images.githubusercontent.com/51970032/116288348-6bf6cc00-a75f-11eb-9919-c6db0b39323b.png)



Solution:
- Update plant uml code to handle on_entry and on_exit, output looks nicer.

[new_plant.txt](https://github.com/boost-ext/sml/files/6386585/new_plant.txt)


![new_plant](https://user-images.githubusercontent.com/51970032/116288434-8630aa00-a75f-11eb-82d7-823df132106b.png)


Issue: #

Reviewers:
@