### PR TITLE
Fix typo in tutorial.md

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -247,7 +247,7 @@ To create a state machine, we have to add a transition table.
 ```cpp
 class example {
 public:
-  auto opeartor()() {
+  auto operator()() {
     using namespace sml;
     return make_transition_table(
      *"src_state"_s + event<my_event> [ guard ] / action = "dst_state"_s,


### PR DESCRIPTION
Problem:
- Copy pasted the code and didn't compile! :)

Solution:
- Swapped a and r

Issue: #

Reviewers:
@