### PR TITLE
:bug: non-copyable dependencies fail to compile, Fix #464

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -354,7 +354,8 @@ struct pool_type_impl : pool_type_base {
   T value;
 };
 template <class T>
-struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value>> : pool_type_base {
+struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value && aux::is_constructible<T, T>::value>>
+    : pool_type_base {
   explicit pool_type_impl(T &value) : value{value} {}
   template <class TObject>
   explicit pool_type_impl(TObject value) : value_{value}, value{value_} {}

--- a/include/boost/sml/aux_/utility.hpp
+++ b/include/boost/sml/aux_/utility.hpp
@@ -152,7 +152,7 @@ struct pool_type_impl : pool_type_base {
 };
 
 template <class T>
-struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value>> : pool_type_base {
+struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value && aux::is_constructible<T, T>::value>> : pool_type_base {
   explicit pool_type_impl(T &value) : value{value} {}
   template <class TObject>
   explicit pool_type_impl(TObject value) : value_{value}, value{value_} {}

--- a/test/ft/state_machine.cpp
+++ b/test/ft/state_machine.cpp
@@ -58,6 +58,26 @@ test sm_ctor = [] {
   (void)sm;
 };
 
+test sm_noncopyable_deps = [] {
+  struct dependency {
+    dependency() = default;
+    dependency(dependency const &) = delete;
+    int i = 0;
+  };
+
+  struct c {
+    auto operator()() const {
+      using namespace sml;
+      return make_transition_table(
+          *("idle"_s) + event<e1> / [](dependency&){}
+      );
+    }
+  };
+
+  dependency d{};
+  sml::sm<c> sm{d};
+};
+
 test sm_ctor_in_array = [] {
   struct c {
     auto operator()() noexcept {


### PR DESCRIPTION
Problem:
- non-copyable deps can't be passed via reference anymore.

Solution:
- Ensure that non-copyable deps can't be injected and won't be copied by the pool.