### PR TITLE
Improving plantuml generation to support:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ PYTHON?=python2
 MKDOCS?=mkdocs
 MKDOCS_THEME?=boost-modern
 MKDOCS_SITE?=site
+PLANTCXX:=$(subst -std=c++14,-std=c++17,$(CXXFLAGS))
 
 all: test example
 
@@ -71,6 +72,14 @@ example: $(patsubst %.cpp, %.out, $(wildcard example/*.cpp))
 
 example/%.out:
 	$(CXX) example/$*.cpp $(CXXFLAGS) -o example/$*.out && $($(MEMCHECK)) example/$*.out
+
+example/plant_uml.out:
+	# try to compile with C++17, if it didn't work C++14 instead
+	$(CXX) example/plant_uml.cpp $(PLANTCXX) -o $@ || true
+	@if [ ! -e "$@" ]; then\
+		$(CXX) example/plant_uml.cpp $(CXXFLAGS) -o $@;\
+	fi
+	$($(MEMCHECK)) $@
 
 style:
 	@find include example test -iname "*.hpp" -or -iname "*.cpp" | xargs $(CLANG_FORMAT) -i

--- a/example/plant_uml.cpp
+++ b/example/plant_uml.cpp
@@ -5,6 +5,440 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
+
+#if __cplusplus >= 201703L
+#include <algorithm>
+#include <boost/sml.hpp>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <typeinfo>
+#include <utility>
+#include <vector>
+
+namespace sml = boost::sml;
+
+struct e1 {};
+struct e2 {};
+struct e3 {};
+struct e4 {};
+struct e5 {};
+
+struct guard {
+  bool operator()() const { return true; }
+} guard;
+
+struct guard2 {
+  bool operator()() const { return true; }
+} guard2;
+
+struct action {
+  void operator()() {}
+} action;
+
+struct action2 {
+  void operator()() {}
+} action2;
+
+void on_s1_entry_f() {}
+void on_s2_exit_f() {}
+
+struct on_s1_entry {
+  auto operator()() { on_s1_entry_f(); }
+} on_s1_entry;
+
+struct on_s2_exit {
+  auto operator()() { on_s2_exit_f(); }
+} on_s2_exit;
+
+struct sub_machine {
+  auto operator()() const noexcept {
+    using namespace sml;
+    // clang-format off
+    return make_transition_table(
+       *"orth1"_s = X
+      ,*"orth2"_s = X
+    );
+    // clang-format on
+  }
+};
+
+struct plant_uml {
+  auto operator()() const noexcept {
+    using namespace sml;
+    // clang-format off
+    return make_transition_table(
+       *"idle"_s + event<e1> = "s1"_s
+      , "s1"_s + event<e2> [ !guard && guard2 ] / action = "s2"_s
+      , "s1"_s + sml::on_entry<_> / on_s1_entry
+      , "s2"_s + event<e3> [ guard || guard2 ] = "s1"_s
+      , "s2"_s + sml::on_exit<_> / on_s2_exit
+      , "s2"_s + event<e4> / action = state<sub_machine>
+      , state<sub_machine> + event<e5> / (action, action2) = X
+    );
+    // clang-format on
+  }
+};
+
+inline void do_indent(unsigned int indent) { std::cout << std::string(indent, ' '); }
+
+// use this to track initialization for orthogonal states
+bool state_initialized = false;  // NOLINT(misc-definitions-in-headers)
+// use this to track which submachines have already been dumped so they don't get dumped twice
+std::vector<std::string> completed_submachines;  // NOLINT(misc-definitions-in-headers)
+
+/** allows for checking if the type is sml::front::seq_
+ * This type is used by sml when there are lists of actions.
+ */
+template <class... Ts>
+struct is_seq_ : sml::aux::false_type {};  // NOLINT(readability-identifier-naming)
+template <class... Ts>
+struct is_seq_<sml::front::seq_<Ts...>> : sml::aux::true_type {};  // NOLINT(readability-identifier-naming)
+
+/** allows for checking if the type is sml::front::not_
+ * This type is used by sml inside of guards, when the guard value is negated with !
+ *
+ * The partial specialization matches if the type passed in is sml::front::not_, causing the struct to
+ * inherit from sml::aux::true_type, which gives it a member called "value" that is set to true.
+ * If the type passed doesn't match sml::front::not_, it'll match the generic is_not_ which inherits
+ * from sml::aux::false_type, giving it a member called "value" that is set to false.
+ */
+template <class... Ts>
+struct is_not_ : sml::aux::false_type {};  // NOLINT(readability-identifier-naming)
+template <class... Ts>
+struct is_not_<sml::front::not_<Ts...>> : sml::aux::true_type {};  // NOLINT(readability-identifier-naming)
+
+/** provides access to the template parameter type of an sml::front::not_<T>
+ */
+template <class T>
+struct strip_not_ {
+  using type = T;
+};  // NOLINT(readability-identifier-naming)
+template <class T>
+struct strip_not_<sml::front::not_<T>> {
+  using type = T;
+};  // NOLINT(readability-identifier-naming)
+
+/** allows for checking if the type is sml::front::and_
+ * This type is used by sml inside of guards when two guard functions are combined with &&
+ */
+template <class... Ts>
+struct is_and_ : sml::aux::false_type {};  // NOLINT(readability-identifier-naming)
+template <class... Ts>
+struct is_and_<sml::front::and_<Ts...>> : sml::aux::true_type {};  // NOLINT(readability-identifier-naming)
+
+/** allows for checking if the type is sml::front::or_
+ * This type is used by sml inside of guards when two guard functions are combined with ||
+ */
+template <class... Ts>
+struct is_or_ : sml::aux::false_type {};  // NOLINT(readability-identifier-naming)
+template <class... Ts>
+struct is_or_<sml::front::or_<Ts...>> : sml::aux::true_type {};  // NOLINT(readability-identifier-naming)
+
+/** uses std::tuple_element and std::tuple to access the Nth type in a parameter pack
+ */
+template <int N, class... Ts>
+using NthTypeOf = typename std::tuple_element<N, std::tuple<Ts...>>::type;
+
+/** gets the size of a parameter pack
+ * this isn't really necessary, sizeof...(Ts) can be used directly instead
+ */
+template <class... Ts>
+struct count {                                     // NOLINT(readability-identifier-naming)
+  static const std::size_t value = sizeof...(Ts);  // NOLINT(readability-identifier-naming)
+};
+
+/** allows for checking if the type is sml::aux::zero_wrapper
+ * sml puts this around types inside of guards and event sequences
+ */
+template <class T>
+struct is_zero_wrapper : sml::aux::false_type {};  // NOLINT(readability-identifier-naming)
+template <class T>
+struct is_zero_wrapper<sml::aux::zero_wrapper<T>> : sml::aux::true_type {};  // NOLINT(readability-identifier-naming)
+
+/** if T is a zero wrapper, ::type will be the inner type. if not, it will be T.
+ */
+template <class T>
+struct strip_zero_wrapper {
+  using type = T;
+};  // NOLINT(readability-identifier-naming)
+template <class T>
+struct strip_zero_wrapper<sml::aux::zero_wrapper<T>> {
+  using type = T;
+};  // NOLINT(readability-identifier-naming)
+
+/** accesses the type of a state-machine, sml::back::sm
+ */
+template <class T>
+struct submachine_type {
+  using type = T;
+};  // NOLINT(readability-identifier-naming)
+template <class T>
+struct submachine_type<sml::back::sm<T>> {
+  using type = typename T::sm;
+};  // NOLINT(readability-identifier-naming)
+
+/** print the types inside a sml::front::seq_
+ * These types came from a list of actions.
+ */
+template <class... Ts>
+struct print_seq_types {  // NOLINT(readability-identifier-naming)
+  template <int I>
+  static void func() {
+    constexpr auto param_pack_empty = (sizeof...(Ts) == I);
+    if constexpr (!param_pack_empty) {  // NOLINT(readability-braces-around-statements,bugprone-suspicious-semicolon)
+      using current_type = NthTypeOf<I, Ts...>;
+      if constexpr (is_seq_<typename current_type::type>::value) {  // NOLINT(readability-braces-around-statements)
+        // handle nested seq_ types, these happen when there are 3 or more actions
+        print_seq_types<typename current_type::type>::template func<0>();
+      } else {  // NOLINT(readability-misleading-indentation)
+        // print this param directly
+        std::cout << sml::aux::string<typename strip_zero_wrapper<current_type>::type>{}.c_str();
+      }
+      if constexpr (I + 1 < sizeof...(Ts)) {  // NOLINT(readability-braces-around-statements,bugprone-suspicious-semicolon)
+        std::cout << ",\\n ";
+      }
+      print_seq_types<Ts...>::template func<I + 1>();
+    }
+  }
+};
+template <class... Ts>
+struct print_seq_types<sml::front::seq_<Ts...>> {  // NOLINT(readability-identifier-naming)
+  template <int I>
+  static void func() {
+    print_seq_types<Ts...>::template func<0>();
+  }
+};
+
+/** print the types inside a guard
+ * These can be a functor, an sml::front::not_, an sml::front::and_, or an sml::front::or_ which makes
+ * this one more complicated. They also involve the zero_wrapper.
+ * The various partial specializations handle all of the possible types.
+ */
+template <class... Ts>
+struct print_guard {  // NOLINT(readability-identifier-naming)
+  template <int I>
+  static void func(const std::string& sep = "") {
+    constexpr auto param_pack_empty = (sizeof...(Ts) == I);
+    if constexpr (!param_pack_empty) {  // NOLINT(readability-braces-around-statements,bugprone-suspicious-semicolon)
+      using current_type = NthTypeOf<I, Ts...>;
+      if constexpr (is_zero_wrapper<
+                        current_type>::value) {  // NOLINT(readability-braces-around-statements,bugprone-suspicious-semicolon)
+        // unwrap the zero_wrapper and put it back into the recursion, it could be anything
+        print_guard<typename strip_zero_wrapper<current_type>::type>::template func<0>();
+      } else {  // NOLINT(readability-misleading-indentation)
+        // it's just a functor, print it
+        std::cout << sml::aux::string<current_type>{}.c_str();
+      }
+
+      // if we're not at the end, print the separator
+      if constexpr (I + 1 < sizeof...(Ts)) {  // NOLINT(readability-braces-around-statements,bugprone-suspicious-semicolon)
+        if (!sep.empty()) {
+          std::cout << sep;
+        }
+      }
+
+      // keep the recursion going, call for the next type in the parameter pack
+      print_guard<Ts...>::template func<I + 1>(sep);
+    }
+  }
+};
+template <class T>
+struct print_guard<sml::front::not_<T>> {  // NOLINT(readability-identifier-naming)
+  template <int I>
+  static void func(const std::string& /*sep*/ = "") {
+    std::cout << "!" << sml::aux::string<typename strip_zero_wrapper<T>::type>{}.c_str();
+  }
+};
+template <class... Ts>
+struct print_guard<sml::front::and_<Ts...>> {  // NOLINT(readability-identifier-naming)
+  template <int I>
+  static void func(const std::string& /*sep*/ = "") {
+    constexpr auto param_pack_empty = (sizeof...(Ts) == I);
+    if constexpr (!param_pack_empty) {
+      print_guard<Ts...>::template func<I>(" &&\\n ");
+    }
+  }
+};
+template <class... Ts>
+struct print_guard<sml::front::or_<Ts...>> {  // NOLINT(readability-identifier-naming)
+  template <int I>
+  static void func(const std::string& /*sep*/ = "") {
+    constexpr auto param_pack_empty = (sizeof...(Ts) == I);
+    if constexpr (!param_pack_empty) {
+      print_guard<Ts...>::template func<I>(" ||\\n ");
+    }
+  }
+};
+
+// forward declaration of dump_transitions
+template <typename...>
+struct dump_transitions;
+
+template <int N, class T>
+void dump_transition() noexcept {
+  constexpr auto src_is_sub_sm =
+      !sml::aux::is_same<sml::aux::type_list<>, sml::back::get_sub_sms<typename T::src_state>>::value;
+  constexpr auto dst_is_sub_sm =
+      !sml::aux::is_same<sml::aux::type_list<>, sml::back::get_sub_sms<typename T::dst_state>>::value;
+
+  std::string src_state, dst_state;
+  // NOLINTNEXTLINE(readability-braces-around-statements)
+  if constexpr (src_is_sub_sm) {
+    src_state = std::string{sml::aux::string<typename submachine_type<typename T::src_state>::type>{}.c_str()};
+  } else {  // NOLINT(readability-misleading-indentation)
+    src_state = std::string{sml::aux::string<typename T::src_state>{}.c_str()};
+  }
+
+  // NOLINTNEXTLINE(readability-braces-around-statements)
+  if constexpr (dst_is_sub_sm) {
+    dst_state = std::string{sml::aux::string<typename submachine_type<typename T::dst_state>::type>{}.c_str()};
+  } else {  // NOLINT(readability-misleading-indentation)
+    dst_state = std::string{sml::aux::string<typename T::dst_state>{}.c_str()};
+  }
+
+  const auto dst_internal = sml::aux::is_same<typename T::dst_state, sml::front::internal>::value;
+
+  const auto has_event = !sml::aux::is_same<typename T::event, sml::anonymous>::value;
+  const auto has_guard = !sml::aux::is_same<typename T::guard, sml::front::always>::value;
+  const auto has_action = !sml::aux::is_same<typename T::action, sml::front::none>::value;
+
+  if (has_event && has_action && sml::aux::is_same<typename T::action::type, sml::front::actions::defer>::value) {
+    do_indent(N);
+    std::cout << src_state << " : " << boost::sml::aux::get_type_name<typename T::event>() << " / defer" << std::endl;
+    return;
+  }
+
+  if (dst_state == "terminate") {
+    dst_state = "[*]";
+  }
+
+  if (T::initial) {
+    if (state_initialized) {  // create an orthogonal section
+      do_indent(N);
+      std::cout << "--" << std::endl;
+    }
+
+    state_initialized = true;
+    do_indent(N);
+    std::cout << "[*] --> " << src_state << std::endl;
+  }
+
+  // NOLINTNEXTLINE(readability-braces-around-statements, bugprone-suspicious-semicolon)
+  if constexpr (src_is_sub_sm) {
+    auto already_in =
+        std::find(completed_submachines.begin(), completed_submachines.end(), src_state) != completed_submachines.end();
+    if (!already_in) {
+      completed_submachines.push_back(src_state);
+      constexpr int indent = N + 2;
+      do_indent(N);
+      std::cout << "state " << src_state << " {" << std::endl;
+      bool prev_state = state_initialized;
+      state_initialized = false;
+      dump_transitions<typename T::src_state::transitions>::template func<indent>();
+      do_indent(N);
+      std::cout << "}" << std::endl;
+      state_initialized = prev_state;
+    }
+  }
+
+  do_indent(N);
+  std::cout << src_state;
+  if (!dst_internal) {
+    std::cout << " --> " << dst_state;
+  }
+
+  if (has_event || has_guard || has_action) {
+    std::cout << " :";
+  }
+
+  if (has_event) {
+    std::cout << " " << std::string{sml::aux::string<typename T::event>{}.c_str()};
+  }
+
+  if (has_guard) {
+    std::cout << "\\n [";
+    print_guard<typename T::guard::type>::template func<0>();
+    std::cout << "]";
+  }
+
+  if (has_action) {
+    std::cout << " /\\n ";
+
+    if constexpr (is_seq_<typename T::action::type>::value) {  // NOLINT(readability-braces-around-statements)
+      std::cout << "(";
+      print_seq_types<typename T::action::type>::template func<0>();
+      std::cout << ")";
+    } else {  // NOLINT(readability-misleading-indentation)
+      std::cout << sml::aux::string<typename T::action::type>{}.c_str();
+    }
+  }
+
+  std::cout << std::endl;
+
+  // NOLINTNEXTLINE(readability-braces-around-statements, bugprone-suspicious-semicolon)
+  if constexpr (dst_is_sub_sm) {
+    auto already_in =
+        std::find(completed_submachines.begin(), completed_submachines.end(), dst_state) != completed_submachines.end();
+    if (!already_in) {
+      completed_submachines.push_back(dst_state);
+      constexpr int indent = N + 2;
+      do_indent(N);
+      std::cout << "state " << dst_state << " {" << std::endl;
+      bool prev_state = state_initialized;
+      state_initialized = false;
+      dump_transitions<typename T::dst_state::transitions>::template func<indent>();
+      do_indent(N);
+      std::cout << "}" << std::endl;
+      state_initialized = prev_state;
+    }
+  }
+}
+
+// this template allows iterating through the types in the parameter pack Ts...
+// I is the counter
+// INDENT is the current indentation level (for the state machine or sub-state machine)
+template <int INDENT, int I, class... Ts>
+void apply_dump_transition() {
+  // iteration is finished when I == the size of the parameter pack
+  constexpr auto param_pack_empty = (sizeof...(Ts) == I);
+  if constexpr (!param_pack_empty) {  // NOLINT(readability-braces-around-statements,bugprone-suspicious-semicolon)
+    // run the dump_transition function to print this sml::front::transition type
+    dump_transition<INDENT, NthTypeOf<I, Ts...>>();
+    // iteration isn't finished, keep going
+    apply_dump_transition<INDENT, I + 1, Ts...>();
+  }
+}
+
+// SFINAE type
+template <typename...>
+struct dump_transitions {  // NOLINT(readability-identifier-naming)
+  template <int INDENT>
+  static void func() {}
+};
+
+// Partial specialization for sml::aux::type_list<Ts...>. This grants access to the
+// types inside the type list, which are sml::front::transition types, so they can
+// be passed to apply_dump_transition.
+template <typename... Ts>
+struct dump_transitions<typename sml::aux::type_list<Ts...>> {  // NOLINT(readability-identifier-naming)
+  template <int INDENT>
+  static void func() {
+    apply_dump_transition<INDENT, 0, Ts...>();
+  }
+};
+
+template <class T>
+void dump() noexcept {
+  std::cout << "@startuml" << std::endl << std::endl;
+  dump_transitions<typename sml::sm<T>::transitions>::template func<0>();
+  std::cout << std::endl << "@enduml" << std::endl;
+}
+
+int main() { dump<plant_uml>(); }
+
+#elif __cplusplus == 201402L
+
 #include <boost/sml.hpp>
 #include <cassert>
 #include <iostream>
@@ -65,9 +499,9 @@ void dump_transition() noexcept {
   const auto is_exit = sml::aux::is_same<typename T::event, sml::back::on_exit<sml::_, sml::_>>::value;
 
   // entry / exit entry
-  if(is_entry || is_exit) {
+  if (is_entry || is_exit) {
     std::cout << src_state;
-  } else { // state to state transition
+  } else {  // state to state transition
     std::cout << src_state << " --> " << dst_state;
   }
 
@@ -78,9 +512,9 @@ void dump_transition() noexcept {
   if (has_event) {
     // handle 'on_entry' and 'on_exit' per plant-uml syntax
     auto event = std::string(boost::sml::aux::get_type_name<typename T::event>());
-    if(is_entry) {
+    if (is_entry) {
       event = "entry";
-    } else if(is_exit) {
+    } else if (is_exit) {
       event = "exit";
     }
     std::cout << " " << event;
@@ -114,3 +548,5 @@ int main() {
   sml::sm<plant_uml> sm;
   dump(sm);
 }
+
+#endif

--- a/include/boost/sml/aux_/utility.hpp
+++ b/include/boost/sml/aux_/utility.hpp
@@ -152,7 +152,8 @@ struct pool_type_impl : pool_type_base {
 };
 
 template <class T>
-struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value && aux::is_constructible<T, T>::value>> : pool_type_base {
+struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value && aux::is_constructible<T, T>::value>>
+    : pool_type_base {
   explicit pool_type_impl(T &value) : value{value} {}
   template <class TObject>
   explicit pool_type_impl(TObject value) : value_{value}, value{value_} {}
@@ -371,13 +372,13 @@ template <class T>
 const char *get_type_name() {
 #if defined(_MSC_VER) && !defined(__clang__)  // __pph__
   return detail::get_type_name<T, 39>(__FUNCSIG__, make_index_sequence<sizeof(__FUNCSIG__) - 39 - 8>{});
-#elif defined(__clang__) && (__clang_major__ >= 12) // __pph__
+#elif defined(__clang__) && (__clang_major__ >= 12)  // __pph__
   return detail::get_type_name<T, 50>(__PRETTY_FUNCTION__, make_index_sequence<sizeof(__PRETTY_FUNCTION__) - 50 - 2>{});
-#elif defined(__clang__)  // __pph__
+#elif defined(__clang__)                             // __pph__
   return detail::get_type_name<T, 63>(__PRETTY_FUNCTION__, make_index_sequence<sizeof(__PRETTY_FUNCTION__) - 63 - 2>{});
-#elif defined(__GNUC__)   // __pph__
+#elif defined(__GNUC__)                              // __pph__
   return detail::get_type_name<T, 68>(__PRETTY_FUNCTION__, make_index_sequence<sizeof(__PRETTY_FUNCTION__) - 68 - 2>{});
-#endif                    // __pph__
+#endif                                               // __pph__
 }
 
 #if defined(__cpp_nontype_template_parameter_class)  // __pph__

--- a/test/ft/state_machine.cpp
+++ b/test/ft/state_machine.cpp
@@ -68,9 +68,7 @@ test sm_noncopyable_deps = [] {
   struct c {
     auto operator()() const {
       using namespace sml;
-      return make_transition_table(
-          *("idle"_s) + event<e1> / [](dependency&){}
-      );
+      return make_transition_table(*("idle"_s) + event<e1> / [](dependency &) {});
     }
   };
 


### PR DESCRIPTION
* on_entry and on_exit
* boolean operators for guards !, &&, and ||
* multiple actions
* orthogonal states
* submachines
* replace "terminate" state with plantuml termination syntax [*]
* update example to show these changes + use functor style instead of lambda style so the generated plantuml reads nicer

I strongly suspect this PR will get rejected because it uses C++17 instead of C++14. However, the improvements to plantuml generation are substantial. Is there a way this example could be included for those who use C++17 or could help be provided in removing the reliance on `if constexpr`?

Thank you.
