### PR TITLE
Fix text error in docs.

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -42,7 +42,7 @@ git clone https://github.com/boost-ext/sml && cd sml && make test
   state<class a> + event<e> [ guard1 ] / [](const auto& event) {}          // Error on MSVC-2015, Ok on GCC-5+, Clang-3.4+
 
   const auto guard2 = [] -> bool { return true; }
-  state<class a> + event<e> [ gurad2 ] / [](const auto& event) -> void {}  // Ok on all supported compilers
+  state<class a> + event<e> [ guard2 ] / [](const auto& event) -> void {}  // Ok on all supported compilers
 ```
 
 ###Configuration


### PR DESCRIPTION
gurad2 -> guard2

[_On this page_](https://boost-ext.github.io/sml/overview.html)

## Expected Text

```c++
const auto guard2 = [] -> bool { return true; }
state<class a> + event<e> [ guard2 ] / [](const auto& event) -> void {}  // Ok on all supported compilers
```

## Actual Text

```c++
const auto guard2 = [] -> bool { return true; }
state<class a> + event<e> [ gurad2 ] / [](const auto& event) -> void {}  // Ok on all supported compilers

/* gurad2, not guard2! */
```

## Steps to Reproduce the Problem

1. Open official docs.
2. Open _Overview_ section.
3. Scroll down to the _Supported/Tested compilers_ paragraph.

Issue: [#477](https://github.com/boost-ext/sml/issues/477)
