### PR TITLE
[doc] fix markdown code block

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -370,6 +370,7 @@ make_transition_table(
 
 In such case...
 
+```cpp
 sm.process_event(some_event{}); // "unexpected 'some_event'
 sm.process_event(int{}); // terminate
 assert(sm.is(X));


### PR DESCRIPTION
The missing code block starting triple backquotes made the page to render improperly.

Problem:
- missing opening ` ```cpp ` 

Solution:
- adding it