### PR TITLE
Dispatch Table Return Value

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -320,7 +320,7 @@ Process event might be also triggered on transition table.
 ```
 using namespace sml;
 return make_transition_table(
- *"s1"_s + event<my_event> / process_event(other_event{}) = "s2"_s,
+ *"s1"_s + event<my_event> / process(other_event{}) = "s2"_s,
   "s2"_s + event<other_event> = X
 );
 ```

--- a/test/ft/dispatch_table.cpp
+++ b/test/ft/dispatch_table.cpp
@@ -75,31 +75,31 @@ test dispatch_runtime_event = [] {
 
   {
     runtime_event event{1};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(s1));
   }
 
   {
     runtime_event event{9};
-    dispatcher(event, event.id);
+    expect(!dispatcher(event, event.id));
     expect(sm.is(s1));
   }
 
   {
     runtime_event event{2};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(s2));
   }
 
   {
     runtime_event event{3};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(sml::X));
   }
 
   {
     runtime_event event{5};
-    dispatcher(event, event.id);
+    expect(!dispatcher(event, event.id));
     expect(sm.is(sml::X));
   }
 };
@@ -122,7 +122,7 @@ test dispatch_runtime_event_dynamic_id = [] {
     expect(sm.is(idle));
     auto dispatcher = sml::utility::make_dispatch_table<runtime_event, 1 /*min*/, 10 /*max*/>(sm);
     runtime_event event{4};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(sml::X));
   }
 
@@ -131,7 +131,7 @@ test dispatch_runtime_event_dynamic_id = [] {
     expect(sm.is(idle));
     auto dispatcher = sml::utility::make_dispatch_table<runtime_event, 1 /*min*/, 10 /*max*/>(sm);
     runtime_event event{5};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(sml::X));
   }
 };
@@ -181,7 +181,7 @@ test dispatch_sm_with_rebind_policies = [] {
     expect(sm.is(idle));
     auto dispatcher = sml::utility::make_dispatch_table<runtime_event, 1 /*min*/, 10 /*max*/>(sm);
     runtime_event event{4};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(sml::X));
   }
 
@@ -191,7 +191,7 @@ test dispatch_sm_with_rebind_policies = [] {
     expect(sm.is(idle));
     auto dispatcher = sml::utility::make_dispatch_table<runtime_event, 1 /*min*/, 10 /*max*/>(sm);
     runtime_event event{5};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(sml::X));
   }
 };
@@ -231,28 +231,28 @@ test dispatch_runtime_event_sub_sm = [] {
 
   {
     runtime_event event{1};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(sml::state<sub>));
     expect(0 == in_sub);
   }
 
   {
     runtime_event event{2};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(sml::state<sub>));
     expect(1 == in_sub);
   }
 
   {
     runtime_event event{3};
-    dispatcher(event, event.id);
+    expect(dispatcher(event, event.id));
     expect(sm.is(sml::X));
     expect(1 == in_sub);
   }
 
   {
     runtime_event event{4};
-    dispatcher(event, event.id);
+    expect(!dispatcher(event, event.id));
     expect(sm.is(sml::X));
     expect(1 == in_sub);
   }


### PR DESCRIPTION
Problem:
- The dispatch table (from `make_dispatch_table` did not return the result of `process_event` which it called
- This behavior was inconsistent with the User Guide which specifies that it should return something satisfying `callable<bool, (TEvent, int)>`

Solution:
- Change the return type of the table and `dispatch_event_impl::execute` to bool from void and to return `sm.process_event` 

Tests updated to check the return value at every step, which may be a bit excessive but verifies that it works in all the previous situations.
Also includes a minor update to docs