### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ constexpr auto send_ack = [](const auto& event, sender& s) { s.send(event); };
 
 #### State Machine
 ```cpp
-struct tcp_release final {
+struct tcp_release {
   auto operator()() const {
     using namespace sml;
     /**


### PR DESCRIPTION
Problem:
Error message:
```
 In file included from sml.cc:4:
sml-1.1.6/include/boost/sml.hpp:166:24: error: base 'tcp_release' is marked 'final' struct is_empty_base : T {
                       ^
sml-1.1.6/include/boost/sml.hpp:170:48: note: in instantiation of template class 'boost::sml::aux::is_empty_base<tcp_release, boost::sml::aux::none_type>' requested here struct is_empty : aux::integral_constant<bool, sizeof(is_empty_base<T, none_type>) == sizeof(none_type)> {};
                                               ^
sml-1.1.6/include/boost/sml.hpp:841:48: note: in instantiation of template class 'boost::sml::aux::is_empty<tcp_release>' requested here
    aux::join_t<typename aux::conditional<aux::is_empty<Ts>::value, aux::type_list<>, aux::type_list<Ts>>::type...>;
                                               ^
sml-1.1.6/include/boost/sml.hpp:320:16: note: in instantiation of template type alias 'get_non_empty_t' requested here
  using type = T<Ts...>;
               ^
sml-1.1.6/include/boost/sml.hpp:323:1: note: in instantiation of template class 'boost::sml::aux::apply<boost::sml::back::get_non_empty_t, boost::sml::aux::type_list<tcp_release>>' requested here using apply_t = typename apply<T, D>::type;
^
sml-1.1.6/include/boost/sml.hpp:1706:25: note: in instantiation of template type alias 'apply_t' requested here
  using sm_all_t = aux::apply_t<get_non_empty_t, aux::join_t<aux::type_list<sm_t>, aux::apply_t<get_sm_t, state_machines>>>;
                        ^
sml.cc:66:13: note: in instantiation of template class 'boost::sml::back::sm<boost::sml::back::sm_policy<tcp_release>>' requested here
  auto sm = sml::sm<tcp_release>{ s };
            ^
sml.cc:43:8: note: 'tcp_release' declared here
struct tcp_release final
       ^           ~~~~~
1 error generated.
```

Solution:
Remove `final`.

Issue: #

Reviewers:
@