### PR TITLE
Add workflow for MSVC and fix compilation errors.

### DIFF
--- a/.github/workflows/build_matrix.yml
+++ b/.github/workflows/build_matrix.yml
@@ -20,6 +20,13 @@ jobs:
             generators: "Ninja"
           }
         - {
+            name: "windows MSVC",
+            os: windows-latest,
+            build_type: "Debug",
+            cxx: "cl",
+            generators: "Ninja"
+          }
+        - {
             name: "ubuntu g++",
             os: ubuntu-latest,
             build_type: "Debug",
@@ -36,6 +43,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Add msbuild to PATH env
+        if: matrix.config.name == 'windows MSVC'
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install dependencies on windows
         if: startsWith(matrix.config.os, 'windows')

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /BUILD*/
 /*.log
 *.out
+.vs
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 #    List available test: $ctest -N
 #    Launch benchmark tests: $ctest -R benchmark*
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 project(sml LANGUAGES CXX)
 include(CTest)
 
@@ -42,9 +42,16 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" AND CMAKE_CXX_COMPILER_VERSION
 endif()
 
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag(-std=c++14 HAS_CXX14_FLAG)
-check_cxx_compiler_flag(-std=c++17 HAS_CXX17_FLAG)
-check_cxx_compiler_flag(-std=c++2a HAS_CXX20_FLAG)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR 
+    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC"))    
+  check_cxx_compiler_flag(/std:c++14 HAS_CXX14_FLAG)
+  check_cxx_compiler_flag(/std:c++17 HAS_CXX17_FLAG)
+  check_cxx_compiler_flag(/std:c++20 HAS_CXX20_FLAG)
+else()
+  check_cxx_compiler_flag(-std=c++14 HAS_CXX14_FLAG)
+  check_cxx_compiler_flag(-std=c++17 HAS_CXX17_FLAG)
+  check_cxx_compiler_flag(-std=c++2a HAS_CXX20_FLAG)
+endif()
 
 if(HAS_CXX20_FLAG)
   set(CMAKE_CXX_STANDARD 20)
@@ -82,7 +89,8 @@ target_include_directories(sml INTERFACE
 
 target_compile_features(sml INTERFACE cxx_std_14)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR 
+    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC"))
   target_compile_definitions(sml
     INTERFACE NOMINMAX # avoid Win macro definition of min/max, use std one
     INTERFACE _SCL_SECURE_NO_WARNINGS # disable security-paranoia warning

--- a/example/eval.cpp
+++ b/example/eval.cpp
@@ -15,8 +15,8 @@ struct e1 {};
 
 struct eval {
   auto operator()() const {
-    constexpr auto guard = [] { return true; };
-    constexpr auto action = [](int &a) { ++a; };
+    const auto guard = [] { return true; };
+    const auto action = [](int &a) { ++a; };
 
     // clang-format off
     using namespace sml;

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -186,7 +186,7 @@ template <class R, class T, class... TArgs>
 struct function_traits<R (T::*)(TArgs...) const> {
   using args = type_list<TArgs...>;
 };
-#if __cplusplus > 201402L && __cpp_noexcept_function_type >= 201510
+#if defined(__cpp_noexcept_function_type)
 template <class R, class... TArgs>
 struct function_traits<R (*)(TArgs...) noexcept> {
   using args = type_list<TArgs...>;
@@ -545,13 +545,14 @@ const char *get_type_name() {
   return detail::get_type_name<T, 68>(__PRETTY_FUNCTION__, make_index_sequence<sizeof(__PRETTY_FUNCTION__) - 68 - 2>{});
 #endif
 }
-#if defined(__cpp_nontype_template_parameter_class)
+#if defined(__cpp_nontype_template_parameter_class) || \
+    defined(__cpp_nontype_template_args) && __cpp_nontype_template_args >= 201911L
 template <auto N>
 struct fixed_string {
   static constexpr auto size = N;
   char data[N + 1]{};
   constexpr fixed_string(char const *str) {
-    for (auto i = 0; i < N; ++i) {
+    for (decltype(N) i = 0; i < N; ++i) {
       data[i] = str[i];
     }
   }
@@ -2714,7 +2715,8 @@ template <class T>
 typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
 #endif
 inline namespace literals {
-#if defined(__cpp_nontype_template_parameter_class)
+#if defined(__cpp_nontype_template_parameter_class) || \
+    defined(__cpp_nontype_template_args) && __cpp_nontype_template_args >= 201911L
 template <aux::fixed_string Str>
 constexpr auto operator""_s() {
   return []<auto... Ns>(aux::index_sequence<Ns...>) { return front::state<aux::string<char, Str.data[Ns]...>>{}; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,8 +16,9 @@ add_definitions(
 
 add_subdirectory(unit)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  add_compile_options("-FI common/test.hpp")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR 
+    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC"))
+  add_compile_options("-FIcommon/test.hpp")
 else()
   add_compile_options(-include common/test.hpp)
 endif()

--- a/test/ft/state_machine.cpp
+++ b/test/ft/state_machine.cpp
@@ -68,7 +68,7 @@ test sm_noncopyable_deps = [] {
   struct c {
     auto operator()() const {
       using namespace sml;
-      return make_transition_table(*("idle"_s) + event<e1> / [](dependency &) {});
+      return make_transition_table(*idle + event<e1> / [](dependency &) {});
     }
   };
 

--- a/test/ft/transitions.cpp
+++ b/test/ft/transitions.cpp
@@ -804,13 +804,13 @@ test member_functions_as_actions_and_guards = [] {
     class0 c;
     int i = 0;
     sml::sm<class0> sm{c, i};
-    sm.process_event(class0::e1{});
+    sm.process_event(class0::e1());
     expect(sm.is(state<class0::s2>));
     expect(i == 1);
-    sm.process_event(class0::e1{});
+    sm.process_event(class0::e1());
     expect(sm.is(state<class0::s3>));
     expect(i == 2);
-    sm.process_event(class0::e1{});
+    sm.process_event(class0::e1());
     expect(sm.is(state<class0::s1>));
     expect(i == 3);
   }

--- a/test/ut/concepts.cpp
+++ b/test/ut/concepts.cpp
@@ -7,7 +7,8 @@
 //
 #include "boost/sml.hpp"
 
-namespace boost::sml::concepts {
+BOOST_SML_NAMESPACE_BEGIN
+namespace concepts {
 
 struct c0 {};
 struct c1 {
@@ -137,3 +138,4 @@ test transitional_concept = [] {
 };
 
 }  // namespace concepts
+BOOST_SML_NAMESPACE_END

--- a/test/ut/type_traits.cpp
+++ b/test/ut/type_traits.cpp
@@ -7,7 +7,8 @@
 //
 #include "boost/sml.hpp"
 
-namespace boost::sml::aux {
+BOOST_SML_NAMESPACE_BEGIN
+namespace aux {
 
 test is_same_types = [] {
   static_expect(!is_same<int, double>::value);
@@ -67,3 +68,4 @@ test is_empty_type = [] {
 };
 
 }  // namespace aux
+BOOST_SML_NAMESPACE_END

--- a/test/ut/utility.cpp
+++ b/test/ut/utility.cpp
@@ -7,7 +7,8 @@
 //
 #include "boost/sml.hpp"
 
-namespace boost::sml::aux {
+BOOST_SML_NAMESPACE_BEGIN
+namespace aux {
 
 test unique_types = [] {
   static_expect(is_same<type_list<>, unique_t<>>::value);
@@ -101,3 +102,4 @@ test type_id_basic = [] {
 };
 
 }  // namespace aux
+BOOST_SML_NAMESPACE_END


### PR DESCRIPTION
Problem:
* Lack of CI workflow for MSVC compiler.
* There are some compilation errors on MSVC.

Solution:
* Add workflow for MSVC with `CMAKE_CXX_COMPILER=cl` and `Generator=Ninja`
* cmake: Change cmake_minimum_required to 3.14 for leveraging CMAKE_CXX_COMPILER_FRONTEND_VARIANT to distinguish between *clang* and *clang-cl*.
* cmake: Use proper cxx compiler flags to check std version for MSVC/Clang-cl.
* cmake: Set cl options for Clang-cl
* eval.cpp: constexpr variable cannot have non-literal type in C++14.
* sml.hpp: Only check __cpp_noexcept_function_type since __cplusplus is not up-to-date on MSVC unless */Zc:__cplusplus* is specified.
* sml.hpp: Use __cpp_nontype_template_args >= 201911L to check whether class type non-type template parameter is supported or not.
* transitions.cpp: Workaround to fix `class0:e1{}` compilation error on MSVC with /std:c++20.
* transition_table.cpp: Workarund to fix operator! deduction issue on MSVC 19.33 with /std:c++20
* concepts.cpp/type_traits.cpp/utility.cpp: Use BOOST_SML_NAMESPACE_BEGIN and BOOST_SML_NAMESPACE_END to fix some weird *inline namespace* issue on MSVC.

Issue: #

Reviewers:
@kris-jusiak 