### PR TITLE
[cmake] clean up and fix warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,38 +41,46 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" AND CMAKE_CXX_COMPILER_VERSION
   message(FATAL_ERROR "sml requires Visual Studio 14 2015 at least")
 endif()
 
+set(IS_COMPILER_GCC_LIKE FALSE)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
+    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR
+    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
+  set(IS_COMPILER_GCC_LIKE TRUE)
+endif()
+
+set(IS_COMPILER_OPTION_GCC_LIKE FALSE)
+set(IS_COMPILER_OPTION_MSVC_LIKE FALSE)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR 
+    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND 
+      "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC"))
+  set(IS_COMPILER_OPTION_MSVC_LIKE TRUE) # cl and clang-cl
+else()
+  set(IS_COMPILER_OPTION_GCC_LIKE TRUE) # g++ and clang++
+endif()
+
 include(CheckCXXCompilerFlag)
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR 
-    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC"))    
+if(IS_COMPILER_OPTION_MSVC_LIKE)    
   check_cxx_compiler_flag(/std:c++14 HAS_CXX14_FLAG)
   check_cxx_compiler_flag(/std:c++17 HAS_CXX17_FLAG)
   check_cxx_compiler_flag(/std:c++20 HAS_CXX20_FLAG)
-else()
+elseif(IS_COMPILER_OPTION_GCC_LIKE)
   check_cxx_compiler_flag(-std=c++14 HAS_CXX14_FLAG)
   check_cxx_compiler_flag(-std=c++17 HAS_CXX17_FLAG)
   check_cxx_compiler_flag(-std=c++2a HAS_CXX20_FLAG)
 endif()
 
-if(HAS_CXX20_FLAG)
-  set(CMAKE_CXX_STANDARD 20)
-elseif(HAS_CXX17_FLAG)
-  set(CMAKE_CXX_STANDARD 17)
-elseif(HAS_CXX14_FLAG)
-  set(CMAKE_CXX_STANDARD 14)
-else()
-  message(FATAL_ERROR "sml requires c++14")
-endif()
-
-if(NOT (DEFINED CMAKE_CXX_STANDARD) OR CMAKE_CXX_STANDARD STREQUAL "" OR CMAKE_CXX_STANDARD LESS 14)
+if(NOT (DEFINED CMAKE_CXX_STANDARD))
+  if(HAS_CXX20_FLAG)
+    set(CMAKE_CXX_STANDARD 20)
+  elseif(HAS_CXX17_FLAG)
+    set(CMAKE_CXX_STANDARD 17)
+  elseif(HAS_CXX14_FLAG)
+    set(CMAKE_CXX_STANDARD 14)
+  else()
     message(FATAL_ERROR "sml requires c++14")
-endif()
-
-set(IS_COMPILER_GCC_LIKE FALSE)
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
-    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR
-    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
-
-  set(IS_COMPILER_GCC_LIKE TRUE)
+  endif()
+elseif(CMAKE_CXX_STANDARD STREQUAL "" OR CMAKE_CXX_STANDARD LESS 14)
+  message(FATAL_ERROR "sml requires c++14")
 endif()
 
 set(CXX_STANDARD_REQUIRED ON)
@@ -89,8 +97,7 @@ target_include_directories(sml INTERFACE
 
 target_compile_features(sml INTERFACE cxx_std_14)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR 
-    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC"))
+if (IS_COMPILER_OPTION_MSVC_LIKE)
   target_compile_definitions(sml
     INTERFACE NOMINMAX # avoid Win macro definition of min/max, use std one
     INTERFACE _SCL_SECURE_NO_WARNINGS # disable security-paranoia warning
@@ -99,7 +106,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR
     target_compile_definitions(sml
       INTERFACE _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
   endif()
-elseif (IS_COMPILER_GCC_LIKE) # gcc
+elseif (IS_COMPILER_OPTION_GCC_LIKE)
   # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
   target_compile_options(sml INTERFACE
     $<BUILD_INTERFACE:

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,68 +6,52 @@
 #
 project(example LANGUAGES CXX)
 
-include_directories(AFTER
-    ${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR})
 
 source_group(example)
 
-if (IS_COMPILER_GCC_LIKE)
-    add_example(actions_guards actions_guards actions_guards.cpp)
-    add_example(arduino arduino arduino.cpp)
-    add_example(composite example_composite composite.cpp)
-    add_example(data example_data data.cpp)
-    add_example(defer_and_process example_defer_and_process defer_and_process.cpp)
-    add_example(dependencies example_dependencies dependencies.cpp)
-endif()
+if(IS_COMPILER_GCC_LIKE)
+  add_example(actions_guards actions_guards actions_guards.cpp)
+  add_example(arduino arduino arduino.cpp)
+  add_example(composite example_composite composite.cpp)
+  add_example(data example_data data.cpp)
+  add_example(defer_and_process example_defer_and_process defer_and_process.cpp)
+  add_example(dependencies example_dependencies dependencies.cpp)
+  add_example(dependency_injection example_dependency_injection
+              dependency_injection.cpp)
+  add_example(dispatch_table example_dispatch_table dispatch_table.cpp)
+  add_example(dispatch_policy example_poilcy dispatch_policy.cpp)
 
-if (NOT IS_MSVC_2015)
-    add_executable(dependency_injection dependency_injection.cpp)
-    add_test(example_dependency_injection dependency_injection)
-endif()
-
-if (IS_COMPILER_GCC_LIKE)
-    add_example(dispatch_table example_dispatch_table dispatch_table.cpp)
-    add_example(dispatch_policy example_poilcy dispatch_policy.cpp)
-
-    if (${SML_USE_EXCEPTIONS})
-    add_executable(error_handling error_handling.cpp)
-    target_link_libraries(error_handling PUBLIC sml)
-    add_test(example_error_handling error_handling)
-    if (IS_COMPILER_GCC_LIKE)
-        target_compile_options(error_handling PRIVATE
-        "-fexceptions") # Enable exception handling
+  if(${SML_USE_EXCEPTIONS})
+    add_example(error_handling example_error_handling error_handling.cpp)
+    if(IS_COMPILER_OPTION_GCC_LIKE)
+      target_compile_options(
+        error_handling PRIVATE "-fexceptions") # Enable exception handling
     endif()
-    endif()
+  endif()
+
+  add_example(euml_emulation example_euml_emulation euml_emulation.cpp)
+  add_example(events example_events events.cpp)
+  if(IS_COMPILER_OPTION_GCC_LIKE)
+    target_compile_options(events PRIVATE "-Wno-unused-parameter")
+  endif()
+
+  add_example(eval example_eval eval.cpp)
 endif()
 
-if (IS_COMPILER_GCC_LIKE)
-    add_example(euml_emulation example_euml_emulation euml_emulation.cpp)
+add_example(hello_world example_hello_world hello_world.cpp)
 
-    add_executable(events events.cpp)
-    target_link_libraries(events PUBLIC sml)
-    add_test(example_events events)
-
-    if (IS_COMPILER_GCC_LIKE)
-        target_compile_options(events PRIVATE
-            "-Wno-unused-parameter")
-    endif()
-endif()
-
-if (NOT IS_MSVC_2015)
-    add_example(hello_world example_hello_world hello_world.cpp)
-endif()
-
-if (IS_COMPILER_GCC_LIKE)
-    add_example(eval example_eval eval.cpp)
-    add_example(history example_history history.cpp)
-    add_example(in_place example_in_place in_place.cpp)
-    add_example(logging example_logging logging.cpp)
-    add_example(nested example_nested nested.cpp)
-    add_example(orthogonal_regions example_orthogonal_regions orthogonal_regions.cpp)
-    add_example(plant_uml example_plant_uml plant_uml.cpp)
-    add_example(sdl2 example_sdl2 sdl2.cpp)
-    add_example(states example_states states.cpp)
-    add_example(testing example_testing testing.cpp)
-    add_example(transitions example_transitions transitions.cpp)
-    add_example(visitor example_visitor visitor.cpp)
+if(IS_COMPILER_GCC_LIKE)
+  add_example(history example_history history.cpp)
+  add_example(in_place example_in_place in_place.cpp)
+  add_example(logging example_logging logging.cpp)
+  add_example(nested example_nested nested.cpp)
+  add_example(orthogonal_regions example_orthogonal_regions
+              orthogonal_regions.cpp)
+  add_example(plant_uml example_plant_uml plant_uml.cpp)
+  add_example(sdl2 example_sdl2 sdl2.cpp)
+  add_example(states example_states states.cpp)
+  add_example(testing example_testing testing.cpp)
+  add_example(transitions example_transitions transitions.cpp)
+  add_example(visitor example_visitor visitor.cpp)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,20 +6,15 @@
 #
 project(test LANGUAGES CXX)
 
-include_directories(AFTER
-  ${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_definitions(
-  -DCHECK_COMPILE_TIME
-  -DBOOST_ALL_NO_LIB
-  -DBUILD_SHARED_LIBS=OFF)
+add_definitions(-DCHECK_COMPILE_TIME -DBOOST_ALL_NO_LIB -DBUILD_SHARED_LIBS=OFF)
 
 add_subdirectory(unit)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR 
-    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC"))
+if(IS_COMPILER_OPTION_MSVC_LIKE)
   add_compile_options("-FIcommon/test.hpp")
-else()
+elseif(IS_COMPILER_OPTION_GCC_LIKE)
   add_compile_options(-include common/test.hpp)
 endif()
 

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -35,12 +35,12 @@ add_test(test_events test_events)
 
 add_executable(test_exceptions exceptions.cpp)
 add_test(test_exceptions test_exceptions)
-
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(IS_COMPILER_OPTION_GCC_LIKE)
   target_compile_options(test_exceptions PRIVATE "-fexceptions")
-  add_executable(test_fwd fwd.cpp)
-  add_test(test_fwd test_fwd)
-endif ()
+endif()
+
+add_executable(test_fwd fwd.cpp)
+add_test(test_fwd test_fwd)
 
 add_executable(test_history history.cpp)
 add_test(test_history test_history)
@@ -51,8 +51,8 @@ add_test(test_guards test_guards)
 add_executable(test_orthogonal_regions orthogonal_regions.cpp)
 add_test(test_orthogonal_regions test_orthogonal_regions)
 
-#add_executable(test_policies_logging policies_logging.cpp)
-#add_test(test_policies_logging test_policies_logging)
+# add_executable(test_policies_logging policies_logging.cpp)
+# add_test(test_policies_logging test_policies_logging)
 
 add_executable(test_policies_testing policies_testing.cpp)
 add_test(test_policies_testing test_policies_testing)


### PR DESCRIPTION
Problem:
* We should not override CMAKE_CXX_STANDARD if it is defined by user.
* warning: unknown argument ignored in clang-cl: '-fexceptions' [-Wunknown-argument].
* Some build targets in example/CMakeLists.txt are not added by calling add_example().

Solution:
* If CMAKE_CXX_STANDARD is already defined, do not override it.
* Add IS_COMPILER_OPTION_MSVC_LIKE and IS_COMPILER_OPTION_GCC_LIKE vars to set the compiler flags. Fix warning: unknown argument ignored in clang-cl: '-fexceptions' [-Wunknown-argument].
* Use existing add_example() to add build targets.

Reviewers:
@krzysztof-jusiak 