### PR TITLE
Illustrate extensive state copying / Support moving states

### DIFF
--- a/example/data.cpp
+++ b/example/data.cpp
@@ -6,6 +6,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 #include <boost/sml.hpp>
+#include <boost/format.hpp>
 #include <cassert>
 #include <iostream>
 
@@ -13,18 +14,30 @@ namespace sml = boost::sml;
 
 namespace {
 struct connect {
-  int id{};
+  int port{};
 };
 struct disconnect {};
 struct interrupt {};
 
 struct Disconnected {};
 struct Connected {
-  int id{};  /// per state data
+  int port{};  /// per state data
 };
 struct Interrupted {
-  int id{};  /// per state data
+  int port{};  /// per state data
+  static int next_id;
+  int id{};
+
+  Interrupted(int port=-1) : port(port), id(next_id++) { p("ctor"); }
+  Interrupted(const Interrupted& other) : port(other.port), id(next_id++) { p((boost::format("copy ctor: %1% ->") % other.id).str().c_str(), false); };
+  Interrupted& operator=(const Interrupted& other) { port = other.port; p("copy assign"); return *this;};
+  Interrupted(Interrupted&& other) : port(other.port), id(next_id++) { p("move ctor"); };
+  Interrupted& operator=(Interrupted&& other) { port = other.port; p("move assign"); return *this;};
+  ~Interrupted() { p("dtor"); }
+
+  void p(const char* op, bool colon=true) { printf(" %s%s %d\n", op, colon ? ":" : "", id); }
 };
+int Interrupted::next_id = 0;
 
 class data {
   using Self = data;
@@ -35,8 +48,8 @@ class data {
   auto operator()() {
     using namespace boost::sml;
 
-    const auto set = [](const auto& event, Connected& state) { state.id = event.id; };
-    const auto update = [](Connected& src_state, Interrupted& dst_state) { dst_state.id = src_state.id; };
+    const auto set = [](const auto& event, Connected& state) { state.port = event.port; };
+    const auto update = [](Connected& src_state, Interrupted& dst_state) { dst_state.port = src_state.port; };
 
     // clang-format off
     return make_transition_table(
@@ -49,7 +62,7 @@ class data {
   }
 
  private:
-  void print(Connected& state) { std::cout << address << ':' << state.id << '\n'; };
+  void print(Connected& state) { std::cout << address << ':' << state.port << '\n'; };
 
   std::string address{};  /// shared data between states
 };
@@ -57,7 +70,7 @@ class data {
 
 int main() {
   data d{std::string{"127.0.0.1"}};
-  sml::sm<data> sm{d, Connected{1}};
+  sml::sm<data> sm{d, Connected{1}, Interrupted()};
   sm.process_event(connect{1024});
   sm.process_event(interrupt{});
   sm.process_event(connect{1025});


### PR DESCRIPTION
Problem: I have a complex state that is only movable but not copyable, which makes SML fail to compile.
I extended the data example to understand and illustrate the problem.

Solution: SML should `move` states around by default and only resort to copying if that's not feasible.

Test output illustrating extensive state copying, here of `Interrupted` state:
```
 ctor: 0
 copy ctor: 0 -> 1
 copy ctor: 1 -> 2
 copy ctor: 2 -> 3
 dtor: 2
 copy ctor: 3 -> 4
 copy ctor: 4 -> 5
 dtor: 4
 dtor: 3
 dtor: 1
 copy ctor: 0 -> 6
 copy ctor: 6 -> 7
 copy ctor: 7 -> 8
 dtor: 7
 copy ctor: 8 -> 9
 dtor: 9
 dtor: 8
 dtor: 6
 dtor: 0
127.0.0.1:1024
127.0.0.1:1024
127.0.0.1:1025
127.0.0.1:1025
 dtor: 5
```