### PR TITLE
compiler error when combining actions and a logger

### DIFF
--- a/example/data.cpp
+++ b/example/data.cpp
@@ -12,6 +12,35 @@
 namespace sml = boost::sml;
 
 namespace {
+struct printf_logger
+{
+  template <class SM, class TEvent>
+  void log_process_event(const TEvent&)
+  {
+    std::printf("[%s][event] %s\n", sml::aux::get_type_name<SM>(), sml::aux::get_type_name<TEvent>());
+  }
+
+  template <class SM, class TGuard, class TEvent>
+  void log_guard(const TGuard&, const TEvent&, bool result)
+  {
+    std::printf("[%s][guard] %s(%s): %s\n", sml::aux::get_type_name<SM>(), sml::aux::get_type_name<TGuard>(),
+                sml::aux::get_type_name<TEvent>(), (result ? "accept" : "reject"));
+  }
+
+  template <class SM, class TAction, class TEvent>
+  void log_action(const TAction&, const TEvent&)
+  {
+    std::printf("[%s][action] %s(%s)\n", sml::aux::get_type_name<SM>(), sml::aux::get_type_name<TAction>(),
+                sml::aux::get_type_name<TEvent>());
+  }
+
+  template <class SM, class TSrcState, class TDstState>
+  void log_state_change(const TSrcState& src, const TDstState& dst)
+  {
+    std::printf("[%s][transition] %s -> %s\n", sml::aux::get_type_name<SM>(), src.c_str(), dst.c_str());
+  }
+};
+
 struct connect {
   int id{};
 };
@@ -53,11 +82,14 @@ class data {
 
   std::string address{};  /// shared data between states
 };
+
 }  // namespace
+
+printf_logger logger;
 
 int main() {
   data d{std::string{"127.0.0.1"}};
-  sml::sm<data> sm{d, Connected{1}};
+  sml::sm<data, sml::logger<printf_logger>> sm{d, Connected{1}, logger};
   sm.process_event(connect{1024});
   sm.process_event(interrupt{});
   sm.process_event(connect{1025});

--- a/example/data.cpp
+++ b/example/data.cpp
@@ -64,15 +64,12 @@ class data {
   auto operator()() {
     using namespace boost::sml;
 
-    const auto set = [](const auto& event, Connected& state) { state.id = event.id; };
-    const auto update = [](Connected& src_state, Interrupted& dst_state) { dst_state.id = src_state.id; };
-
     // clang-format off
     return make_transition_table(
-      * state<Disconnected> + event<connect>    / (set, &Self::print)    = state<Connected>
-      , state<Connected>    + event<interrupt>  / (update, &Self::print) = state<Interrupted>
-      , state<Interrupted>  + event<connect>    / (set, &Self::print)    = state<Connected>
-      , state<Connected>    + event<disconnect> / (&Self::print)         = X
+      * state<Disconnected> + event<connect>    = state<Connected>
+      , state<Connected>    + event<interrupt>  = state<Interrupted>
+      , state<Interrupted>  + event<connect>    = state<Connected>
+      , state<Connected>    + event<disconnect> = X
     );
     // clang-format on
   }


### PR DESCRIPTION
Adding a simple logger to the data.cpp example yields a compiler error (1st commit)
Removing the actions from the transition table, resolves the compiler error (2nd commit)
Problem: Obviously actions and a logger cannot be combined

Solution: This PR just illustrates the bug. I don't have a solution.