### PR TITLE
Fix thread safety

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1396,6 +1396,8 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   }
   template <class TEvent, class TDeps, class TSubs>
   bool process_event(const TEvent &event, TDeps &deps, TSubs &subs) {
+    const auto lock = thread_safety_.create_lock();
+    (void)lock;
     bool handled = process_internal_events(event, deps, subs);
     do {
       do {
@@ -1510,15 +1512,11 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   template <class TMappings, class TEvent, class TDeps, class TSubs, class... TStates>
   bool process_event_impl(const TEvent &event, TDeps &deps, TSubs &subs, const aux::type_list<TStates...> &states,
                           aux::index_sequence<0>) {
-    const auto lock = thread_safety_.create_lock();
-    (void)lock;
     return dispatch_t::template dispatch<0, TMappings>(*this, current_state_[0], event, deps, subs, states);
   }
   template <class TMappings, class TEvent, class TDeps, class TSubs, class... TStates, int... Ns>
   bool process_event_impl(const TEvent &event, TDeps &deps, TSubs &subs, const aux::type_list<TStates...> &states,
                           aux::index_sequence<Ns...>) {
-    const auto lock = thread_safety_.create_lock();
-    (void)lock;
     auto handled = false;
 #if defined(__cpp_fold_expressions)
     ((handled |= dispatch_t::template dispatch<0, TMappings>(*this, current_state_[Ns], event, deps, subs, states)), ...);
@@ -1532,8 +1530,6 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   template <class TMappings, class TEvent, class TDeps, class TSubs, class... TStates>
   bool process_event_impl(const TEvent &event, TDeps &deps, TSubs &subs, const aux::type_list<TStates...> &states,
                           state_t &current_state) {
-    const auto lock = thread_safety_.create_lock();
-    (void)lock;
     return dispatch_t::template dispatch<0, TMappings>(*this, current_state, event, deps, subs, states);
   }
 #if !BOOST_SML_DISABLE_EXCEPTIONS

--- a/test/ft/policies_thread_safe.cpp
+++ b/test/ft/policies_thread_safe.cpp
@@ -88,7 +88,6 @@ test process_event_reentrant = [] {
     }
   };
 
-  sml::sm<c, sml::process_queue<std::queue>, sml::thread_safe<std::recursive_mutex>> sm;
-  // Hangs forever awaiting lock if mutex is not reentrant.
+  sml::sm<c, sml::process_queue<std::queue>, sml::thread_safe<std::mutex>> sm;
   sm.process_event(e1{});
 };


### PR DESCRIPTION
Problem:
Using `process(...)` within an event handler triggered from multiple threads in parallel causes a segfault, because the access to the root machine's `process_` queue was unprotected. The problem is illustrated in a new unit test.

Solution:
I moved the mutex lock from some very deep `process_event_impl` functions to the top-level `process_event`.
This solution also eliminates the need for a `recursive_mutex` when using `process`.
