### PR TITLE
Fix test pool_init_from_other_pool

### DIFF
--- a/test/ut/utility.cpp
+++ b/test/ut/utility.cpp
@@ -83,8 +83,8 @@ test pool_basic = [] {
 test pool_init_from_other_pool = [] {
   pool<double, int> p{87.0, 42};
   pool<int, double> p2{init{}, static_cast<decltype(p)&&>(p)};
-  expect(42 == get<int>(p));
-  expect(87.0 == get<double>(p));
+  expect(42 == get<int>(p2));
+  expect(87.0 == get<double>(p2));
 };
 
 test is_specialization = [] {


### PR DESCRIPTION
Reviewing the unit tests to understand some issue I have seen, I found this cut-and-paste error: From the test name, I strongly guess, access to elements of `p2` should be tested (instead of `p`, which was already handled in test `pool_basic`).
