### PR TITLE
Always Diagnostic Pop on GCC

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2752,8 +2752,10 @@ BOOST_SML_NAMESPACE_END
 #undef __BOOST_SML_TEMPLATE_KEYWORD
 #if defined(__clang__)
 #pragma clang diagnostic pop
-#elif defined(__GNUC__) && defined(__BOOST_SML_DEFINED_HAS_BUILTIN)
+#elif defined(__GNUC__)
+#if defined(__BOOST_SML_DEFINED_HAS_BUILTIN)
 #undef __has_builtin
+#endif
 #pragma GCC diagnostic pop
 #elif defined(_MSC_VER) && !defined(__clang__) && defined(__BOOST_SML_DEFINED_HAS_BUILTIN)
 #undef __has_builtin


### PR DESCRIPTION
Problem:
- In certain circumstances including `sml.hpp` on GCC performing `#pragma GCC diagnostic push` but not `#pragma GCC diagnostic pop`

Solution:
- Split previously-fused preprocessor check so `#pragma GCC diagnostic pop` doesn't require `__BOOST_SML_DEFINED_HAS_BUILTIN` to be defined