### PR TITLE
Fix bug in dep resolution when requesting a "const T*"

### DIFF
--- a/test/ft/dependencies.cpp
+++ b/test/ft/dependencies.cpp
@@ -179,6 +179,90 @@ test dependencies_smart_ptrs = [] {
   expect(sm.is(sml::X));
 };
 
+test dependencies_with_reference = [] {
+  struct Data {
+    int m_member { 42 };
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      const auto action = [](Data& data) { expect(data.m_member == 42); };
+
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> / action = X);
+    }
+  };
+
+  Data data;
+  sml::sm<c> sm{data};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test dependencies_with_const_reference = [] {
+  struct Data {
+    int m_member { 42 };
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      const auto action = [](const Data& data) {
+        expect(data.m_member == 42);
+      };
+
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> / action = X);
+    }
+  };
+
+  Data data;
+  sml::sm<c> sm{data};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test dependencies_with_pointer = [] {
+  struct Data {
+    int m_member { 42 };
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      const auto action = [](Data* data) { expect(data->m_member == 42); };
+
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> / action = X);
+    }
+  };
+
+  Data data;
+  sml::sm<c> sm{&data};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test dependencies_with_const_pointer = [] {
+  struct Data {
+    int m_member { 42 };
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      const auto action = [](const Data* data) {
+        expect(data->m_member == 42);
+      };
+
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> / action = X);
+    }
+  };
+
+  Data data;
+  sml::sm<c> sm{&data};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
 #if (_MSC_VER >= 1910)  // MSVC 2017
 test dependencies_multiple_subs = [] {
   struct update {


### PR DESCRIPTION
## Duplicate of #347

>Hello,
>I have fixed a bug in dependency resolution when requesting a "const T*" after injecting a "T*" as dependency.
>
> Before this fix, if a T* was injected as dependency, requesting a const T* will result in a invalid nullptr.
> The dependency resolution of objects passed by reference is not affected by this problem.
>
> I have added four tests:
>
> dependencies_with_reference
> dependencies_with_const_reference
> dependencies_with_pointer
> dependencies_with_const_pointer (this test fails without the fix)
> I am new to TMP and this is my first contribute in general so I hope I didn't do anything wrong.

I recently encountered this same issue, figured I'd resolve any merge conflicts so that it's able to be merged in.