### PR TITLE
Allow move-only references as dependencies

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -364,7 +364,7 @@ struct pool_type_impl : pool_type_base {
   T value{};
 };
 template <class T>
-struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value && aux::is_constructible<T, T>::value>>
+struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value && aux::is_constructible<T, const T &>::value>>
     : pool_type_base {
   constexpr explicit pool_type_impl(T &value) : value{value} {}
   template <class TObject>

--- a/test/ft/dependencies.cpp
+++ b/test/ft/dependencies.cpp
@@ -181,7 +181,7 @@ test dependencies_smart_ptrs = [] {
 
 test dependencies_with_reference = [] {
   struct Data {
-    int m_member { 42 };
+    int m_member{42};
   };
 
   struct c {
@@ -201,14 +201,12 @@ test dependencies_with_reference = [] {
 
 test dependencies_with_const_reference = [] {
   struct Data {
-    int m_member { 42 };
+    int m_member{42};
   };
 
   struct c {
     auto operator()() noexcept {
-      const auto action = [](const Data& data) {
-        expect(data.m_member == 42);
-      };
+      const auto action = [](const Data& data) { expect(data.m_member == 42); };
 
       using namespace sml;
       return make_transition_table(*idle + event<e1> / action = X);
@@ -223,7 +221,7 @@ test dependencies_with_const_reference = [] {
 
 test dependencies_with_pointer = [] {
   struct Data {
-    int m_member { 42 };
+    int m_member{42};
   };
 
   struct c {
@@ -243,14 +241,12 @@ test dependencies_with_pointer = [] {
 
 test dependencies_with_const_pointer = [] {
   struct Data {
-    int m_member { 42 };
+    int m_member{42};
   };
 
   struct c {
     auto operator()() noexcept {
-      const auto action = [](const Data* data) {
-        expect(data->m_member == 42);
-      };
+      const auto action = [](const Data* data) { expect(data->m_member == 42); };
 
       using namespace sml;
       return make_transition_table(*idle + event<e1> / action = X);
@@ -259,6 +255,30 @@ test dependencies_with_const_pointer = [] {
 
   Data data;
   sml::sm<c> sm{&data};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test dependencies_move_only_reference = [] {
+  struct Data {
+    std::unique_ptr<int> m_member;
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      const auto action = [](const Data& data) {
+        expect(data.m_member != nullptr);
+        expect(*data.m_member == 42);
+      };
+
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> / action = X);
+    }
+  };
+
+  Data data;
+  data.m_member = std::make_unique<int>(42);
+  sml::sm<c> sm{data};
   sm.process_event(e1{});
   expect(sm.is(sml::X));
 };


### PR DESCRIPTION
Problem:
In my application, I have a move-only struct that I would like to insert as a dependency. I wanted to do this by reference, and not by pointer. I was getting a compiler error because it was not copy-constructible

Solution:
Check that pool of T can use a copy-constructor before trying to use it. BTW, I tried running clang-format on this, and it changed some tests files I did not want to touch. I committed the changes it made in the dependencies test

Issue: #504  <- I'm not sure how exactly what this issue was trying to say, but I suspect it is the same issue

Reviewers:
@krzysztof-jusiak 