### PR TITLE
reduce code size for state machines without orthogonal regions

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1776,7 +1776,17 @@ class sm {
     constexpr auto regions = sm_impl_t::regions;
     aux::cget<sm_impl_t>(sub_sms_).visit_current_states(visitor, states_t{}, aux::make_index_sequence<regions>{});
   }
-  template <class T = aux::identity<sm_t>, class TState>
+  template <class T = aux::identity<sm_t>, class TState,
+            __BOOST_SML_REQUIRES(sm_impl<typename TSM::template rebind<typename T::type>>::regions == 1)>
+  constexpr bool is(const TState &) const {
+    using type = typename T::type;
+    using sm_impl_t = sm_impl<typename TSM::template rebind<type>>;
+    using state_t = typename sm_impl_t::state_t;
+    using states_ids_t = typename sm_impl_t::states_ids_t;
+    return aux::get_id<state_t, typename TState::type>((states_ids_t *)0) == aux::cget<sm_impl_t>(sub_sms_).current_state_[0];
+  }
+  template <class T = aux::identity<sm_t>, class TState,
+            __BOOST_SML_REQUIRES(sm_impl<typename TSM::template rebind<typename T::type>>::regions != 1)>
   constexpr bool is(const TState &) const {
     using type = typename T::type;
     using sm_impl_t = sm_impl<typename TSM::template rebind<type>>;

--- a/test/ft/orthogonal_regions.cpp
+++ b/test/ft/orthogonal_regions.cpp
@@ -46,14 +46,28 @@ test orthogonal_regions = [] {
 
   sml::sm<c> sm;
   expect(sm.is(idle, idle2));
+  expect(sm.is(idle));
+  expect(sm.is(idle2));
+
   sm.process_event(e1{});
   expect(sm.is(s1, idle2));
+  expect(sm.is(s1));
+  expect(sm.is(idle2));
+
   sm.process_event(e2{});
   expect(sm.is(s2, idle2));
+  expect(sm.is(s2));
+  expect(sm.is(idle2));
+
   sm.process_event(e3{});
   expect(sm.is(s2, s3));
+  expect(sm.is(s2));
+  expect(sm.is(s3));
+
   sm.process_event(e4{});
   expect(sm.is(s2, s4));
+  expect(sm.is(s2));
+  expect(sm.is(s4));
 };
 
 test orthogonal_regions_event_consumed_by_all_regions = [] {


### PR DESCRIPTION
Problem:
Since upgrading from 1.1.5 to 1.1.8, the code size of my project increased a lot. 
The cause seems to be the fix to the is(const TState &) function. 
This function was fixed in 1.1.6 to also work for orthogonal regions. 

Solution:
Created an overload with the pre 1.1.6 version of the function which is only selected when orthogonal regions equals 1. 
Also added some tests to make sure the right version is selected when regions is not 1.

Reviewers:
@krzysztof-jusiak 