### PR TITLE
:fire: BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS to optimize memory…

### DIFF
--- a/example/data.cpp
+++ b/example/data.cpp
@@ -5,6 +5,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
+#define BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS
 #include <boost/sml.hpp>
 #include <cassert>
 #include <iostream>

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -363,6 +363,7 @@ struct pool_type_impl : pool_type_base {
   constexpr pool_type_impl(init i, TObject object) : value{i, object} {}
   T value{};
 };
+#if defined(BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS)
 template <class T>
 struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value && aux::is_constructible<T, const T &>::value>>
     : pool_type_base {
@@ -374,6 +375,7 @@ struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value && a
   T value_{};
   T &value;
 };
+#endif
 template <class T>
 struct pool_type : pool_type_impl<T> {
   using pool_type_impl<T>::pool_type_impl;

--- a/test/ft/deep_sm.cpp
+++ b/test/ft/deep_sm.cpp
@@ -11,6 +11,7 @@ The goal of this file is only to compile a state machine with deeply nested
 states that use on_entry events. The only requirement on this file is a
 successful compilation without a ftemplate-depth error.
 */
+#define BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS
 #include <boost/sml.hpp>
 
 namespace sml = boost::sml;

--- a/test/ft/dependencies.cpp
+++ b/test/ft/dependencies.cpp
@@ -5,8 +5,9 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#include <array>
+#define BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS
 #include <boost/sml.hpp>
+#include <array>
 #include <memory>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
… consumption

Problem:
- If dependency is default constructible a copy is stored in sml which increases the memory consumption.

Solution:
- Make the feature optional by passing BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS. Disabled by default as SML is optimized for perf and memory.