### PR TITLE
Added "any state" feature 

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1087,7 +1087,9 @@ template <class T, class, class... Ts>
 transitions<Ts...> get_state_mapping_impl(state_mappings<T, aux::type_list<Ts...>> *);
 template <class T, class TMappings, class TUnexpected>
 struct get_state_mapping {
-  using type = decltype(get_state_mapping_impl<T, TUnexpected>((TMappings *)0));
+  using type = aux::conditional_t<aux::is_same<decltype(get_state_mapping_impl<T, TUnexpected>((TMappings *)0)), transitions<TUnexpected>>::value, 
+      decltype(get_state_mapping_impl<_, TUnexpected>((TMappings *)0)), 
+      decltype(get_state_mapping_impl<T, TUnexpected>((TMappings *)0))>;
 };
 template <class S>
 transitions_sub<S> get_sub_state_mapping_impl(...);


### PR DESCRIPTION
Allowing a default reaction on events without having to add them to every state.
I believe a similar feature exists in sml2

Problem:
-Many (of my) state machines have events that are handled in (almost) all states. For example, transitions to an error state or a stop/abort event. Currently there is no way to express a default reaction to an event. 

Solution:
-Added an "any" state. The any state is written as "state<_>". Whenever an event is processed in a state that does NOT handle that event, the "any" state is checked. If the "any" state handles the event it is processed as if the current state is the "any" state. This change could break code that already uses "state<_>" as a normal state.  

Issue: #328 

Reviewers:
@krzysztof-jusiak 