### PR TITLE
allow the usage of "static queues" (based on std::array) for process_queue and defer_queue

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -658,11 +658,14 @@ class queue_event {
   }
 
  public:
+  constexpr queue_event() : dtor(nullptr) {}
   constexpr queue_event(queue_event &&other) : id(other.id), dtor(other.dtor), move(other.move) {
     move(data, static_cast<queue_event &&>(other));
   }
   constexpr queue_event &operator=(queue_event &&other) {
-    dtor(data);
+    if (dtor != nullptr) {
+      dtor(data);
+    }
     id = other.id;
     dtor = other.dtor;
     move = other.move;
@@ -678,7 +681,11 @@ class queue_event {
     move = &move_impl<T>;
     new (&data) T(static_cast<T &&>(object));
   }
-  ~queue_event() { dtor(data); }
+  ~queue_event() {
+    if (dtor) {
+      dtor(data);
+    }
+  }
   alignas(alignment) aux::byte data[size];
   int id = -1;
 

--- a/test/ft/static_deque.h
+++ b/test/ft/static_deque.h
@@ -1,0 +1,78 @@
+#ifndef STATIC_DEQUE_H
+#define STATIC_DEQUE_H
+
+#include <array>
+#include <stdexcept>
+
+template <typename T, std::size_t Size>
+struct MinimalStaticDeque {
+  std::array<T, Size> queue_data{};
+  std::size_t current_index = 0;
+
+  using value_type = typename decltype(queue_data)::value_type;
+  using reference = typename decltype(queue_data)::reference;
+  using const_reference = typename decltype(queue_data)::const_reference;
+  using size_type = typename decltype(queue_data)::size_type;
+  using difference_type = typename decltype(queue_data)::difference_type;
+  using pointer = typename decltype(queue_data)::pointer;
+  using const_pointer = typename decltype(queue_data)::const_pointer;
+  using iterator = typename decltype(queue_data)::iterator;
+  using const_iterator = typename decltype(queue_data)::const_iterator;
+  using reverse_iterator = typename decltype(queue_data)::reverse_iterator;
+  using const_reverse_iterator = typename decltype(queue_data)::const_reverse_iterator;
+
+  void push_back(T&& t) { queue_data[current_index++] = std::move(t); }
+  T& front() {
+    if (current_index == 0) {
+      throw std::out_of_range("queue is empty");
+    }
+    return queue_data[0];
+  }
+  T& back() {
+    if (current_index == 0) {
+      throw std::out_of_range("queue is empty");
+    }
+    return queue_data[current_index - 1];
+  }
+  void pop_front() {
+    if (current_index == 0) {
+      throw std::out_of_range("queue is empty");
+    }
+    std::move(std::next(queue_data.begin()), queue_data.end(), queue_data.begin());
+    current_index--;
+  }
+  void pop_back() {  // removes the last element
+    if (current_index == 0) {
+      throw std::out_of_range("queue is empty");
+    }
+    current_index--;
+  }
+  void push_front(T&& value) {
+    if (current_index == Size) {
+      throw std::runtime_error("queue is full");
+    }
+    std::move_backward(begin(), end(), std::next(end()));
+    queue_data[0] = std::move(value);
+    current_index++;
+  }
+  bool empty() const { return current_index == 0; }
+
+  iterator begin() { return queue_data.begin(); }
+  const_iterator cbegin() const { return queue_data.cbegin(); }
+
+  iterator end() { return std::next(queue_data.begin(), current_index); }
+  const_iterator cend() const { return std::next(queue_data.begin(), current_index); }
+
+  iterator erase(const_iterator pos) {
+    if (pos == end()) {
+      throw std::out_of_range("queue is empty");
+    }
+    const auto position = std::distance(cbegin(), pos);
+    auto start = queue_data.begin() + position;
+    std::move(std::next(start), end(), start);
+    current_index--;
+    return start;
+  }
+};
+
+#endif  // STATIC_DEQUE_H

--- a/test/ft/static_queue.h
+++ b/test/ft/static_queue.h
@@ -1,0 +1,50 @@
+#ifndef STATIC_QUEUE_H
+#define STATIC_QUEUE_H
+
+#include <array>
+#include <stdexcept>
+
+template <typename T, std::size_t Size>
+struct MinimalStaticQueue {
+  std::array<T, Size> queue_data{};
+  std::size_t current_index = 0;
+
+  using value_type = typename decltype(queue_data)::value_type;
+  using reference = typename decltype(queue_data)::reference;
+  using const_reference = typename decltype(queue_data)::const_reference;
+  using size_type = typename decltype(queue_data)::size_type;
+  using difference_type = typename decltype(queue_data)::difference_type;
+  using pointer = typename decltype(queue_data)::pointer;
+  using const_pointer = typename decltype(queue_data)::const_pointer;
+  using iterator = typename decltype(queue_data)::iterator;
+  using const_iterator = typename decltype(queue_data)::const_iterator;
+  using reverse_iterator = typename decltype(queue_data)::reverse_iterator;
+  using const_reverse_iterator = typename decltype(queue_data)::const_reverse_iterator;
+
+  void push(T&& t) { queue_data[current_index++] = std::move(t); }
+  T& front() {
+    if (current_index == 0) {
+      throw std::out_of_range("queue is empty");
+    }
+    return queue_data[0];
+  }
+  T& back() {
+    if (current_index == 0) {
+      throw std::out_of_range("queue is empty");
+    }
+    return queue_data[current_index - 1];
+  }
+  iterator begin() { return queue_data.begin(); }
+  iterator end() { return std::next(queue_data.begin(), current_index); }
+
+  void pop() {  // removes the first element
+    if (current_index == 0) {
+      throw std::out_of_range("queue is empty");
+    }
+    std::move(std::next(begin()), end(), begin());
+    current_index--;
+  }
+  bool empty() const { return current_index == 0; }
+};
+
+#endif  // STATIC_QUEUE_H


### PR DESCRIPTION


Problem:
-
All examples for `sml::process_queue` and `sml::defer_queue` are based on `std::queue`.
While this approach is fine for desktop c++, some use cases exist where dynamic allocations are not allowed / desired.

Some examples are:

- embedded systems (no dynamic memory allocations available)
- real-time systems with pre-allocated objects

As boost::sml is a library that targets embedded systems, it should allow the use of pre-allocated queues.

Solution:
-
I enabled the use of pre-allocated queues by making `queue_event` default constructible.
This allows storing instances of `queue_event` in a container that pre-allocates all elements upon construction (e.g.
`std::array`).

I added additional tests in `actions_process.cpp`, `actions_defer.cpp` and `actions_process_n_defer.cpp` that
use `std::array` based queues and deques.