### PR TITLE
Handle anonymous events with process_internal_events

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1013,7 +1013,7 @@ struct transitions_sub<sm<Tsm>, T, Ts...> {
     if (sub_sm<sm_impl<Tsm>>::cget(&subs).is_terminated()) {
       return transitions<T, Ts...>::execute(event, sm, deps, subs, current_state);
     } else {
-      return sub_sm<sm_impl<Tsm>>::get(&subs).process_event(event, deps, subs);
+      return sub_sm<sm_impl<Tsm>>::get(&subs).process_internal_events(event, deps, subs);
     }
     return false;
   }
@@ -1044,8 +1044,8 @@ struct transitions_sub<sm<Tsm>> {
     return sub_sm<sm_impl<Tsm>>::get(&subs).process_event(event, deps, subs);
   }
   template <class, class SM, class TDeps, class TSubs>
-  constexpr static bool execute(const anonymous &, SM &, TDeps &, TSubs &, typename SM::state_t &) {
-    return false;
+  constexpr static bool execute(const anonymous &, SM &, TDeps &deps, TSubs &subs, typename SM::state_t &) {
+    return sub_sm<sm_impl<Tsm>>::get(&subs).process_internal_events(anonymous{}, deps, subs);
   }
 };
 }  // namespace back


### PR DESCRIPTION
- Address missing initial anonymous transitions in composite states
- Eliminate exponential internal generation of anonymous events in nested states

Problem:
- Some initial anonymous events in nested composite states are missed
- Anonymous events are generated in composite states in exponential proportion to the number of levels

Solution:
- Restore anonymous event handling in one `transitions_sub::execute()` method
- Use the lighter weight `process_internal_events` for anonymous events to avoid explosion

Issue: #544

Reviewers:
@kris-jusiak @GuiCodron @mechatheo