### PR TITLE
fix deferred events not processed in non-first orthogonal region

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1786,15 +1786,19 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
     const auto lock = thread_safety_.create_lock();
     (void)lock;
     bool changed = false;
-    state_t old = current_state_[0];
+    state_t old[regions];
+    for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
     bool handled = process_internal_events(event, deps, subs);
     bool queued_handled = true;
     do {
       do {
         while (process_internal_events(anonymous{}, deps, subs)) {
         }
-        changed = (old != current_state_[0]);
-        old = current_state_[0];
+        changed = false;
+        for (auto i = 0u; i < regions; ++i) {
+          if (old[i] != current_state_[i]) { changed = true; break; }
+        }
+        for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
       } while (process_defer_events(deps, subs, changed, aux::type_wrapper<defer_queue_t<TEvent>>{}, events_t{}));
     } while (process_queued_events(deps, subs, queued_handled, aux::type_wrapper<process_queue_t<TEvent>>{}, events_t{}));
     return handled && queued_handled;
@@ -1993,13 +1997,18 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
       defer_again_ = false;
       defer_it_ = defer_.begin();
       defer_end_ = defer_.end();
-      state_t old = current_state_[0];
+      state_t old[regions];
+      for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
       while (defer_it_ != defer_end_) {
         processed_events |= (this->*dispatch_table[defer_it_->id])(deps, subs, defer_it_->data);
         defer_again_ = false;
-        if (old != current_state_[0]) {
+        bool state_changed = false;
+        for (auto i = 0u; i < regions; ++i) {
+          if (old[i] != current_state_[i]) { state_changed = true; break; }
+        }
+        if (state_changed) {
           defer_it_ = defer_.begin();
-          old = current_state_[0];
+          for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
         }
       }
       defer_processing_ = false;

--- a/test/ft/actions_defer.cpp
+++ b/test/ft/actions_defer.cpp
@@ -364,3 +364,26 @@ test defer_minimal_static_deque = [] {
   sm.process_event(event2());
   expect(sm.is(sml::X));
 };
+
+const auto dummy = sml::state<class dummy>;
+
+test defer_non_first_orthogonal_region = [] {
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *dummy  + event<event4> = X       // region 0 (dummy, never fires)
+        ,*state1 + event<event1> / defer   // region 1: defer e1
+        , state1 + event<event2> = state2
+        , state2 + event<event1> = state1
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c, sml::defer_queue<std::deque>> sm{};
+  sm.process_event(event1());  // deferred
+  sm.process_event(event2());  // state1->state2; deferred event1 fires: state2->state1
+  expect(sm.is(state1));
+};


### PR DESCRIPTION
Fixes #611.

Both `process_event` and `process_defer_events` only compared `current_state_[0]` to detect state changes. A transition in any region other than the first left `changed = false`, so deferred events were never replayed.

Fix: snapshot and compare all `regions` elements instead of just index 0.