### PR TITLE
fix -Wcast-align in queue_event

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -929,13 +929,13 @@ class queue_event {
   static constexpr auto alignment = aux::max_element<alignof(Ts)...>();
   static constexpr auto size = aux::max_element<sizeof(Ts)...>();
   template <class T>
-  constexpr static void dtor_impl(aux::byte *data) {
+  constexpr static void dtor_impl(void *data) {
     (void)data;
-    reinterpret_cast<T *>(data)->~T();
+    static_cast<T *>(data)->~T();
   }
   template <class T>
   constexpr static void move_impl(aux::byte (&data)[size], queue_event &&other) {
-    new (&data) T(static_cast<T &&>(*reinterpret_cast<T *>(other.data)));
+    new (&data) T(static_cast<T &&>(*static_cast<T *>(static_cast<void *>(other.data))));
   }
 
  public:
@@ -971,7 +971,7 @@ class queue_event {
   int id = -1;
 
  private:
-  void (*dtor)(aux::byte *);
+  void (*dtor)(void *);
   void (*move)(aux::byte (&)[size], queue_event &&);
 };
 template <class TEvent>

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1786,15 +1786,19 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
     const auto lock = thread_safety_.create_lock();
     (void)lock;
     bool changed = false;
-    state_t old = current_state_[0];
+    state_t old[regions];
+    for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
     bool handled = process_internal_events(event, deps, subs);
     bool queued_handled = true;
     do {
       do {
         while (process_internal_events(anonymous{}, deps, subs)) {
         }
-        changed = (old != current_state_[0]);
-        old = current_state_[0];
+        changed = false;
+        for (auto i = 0u; i < regions; ++i) {
+          if (old[i] != current_state_[i]) { changed = true; break; }
+        }
+        for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
       } while (process_defer_events(deps, subs, changed, aux::type_wrapper<defer_queue_t<TEvent>>{}, events_t{}));
     } while (process_queued_events(deps, subs, queued_handled, aux::type_wrapper<process_queue_t<TEvent>>{}, events_t{}));
     return handled && queued_handled;
@@ -1993,13 +1997,18 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
       defer_again_ = false;
       defer_it_ = defer_.begin();
       defer_end_ = defer_.end();
-      state_t old = current_state_[0];
+      state_t old[regions];
+      for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
       while (defer_it_ != defer_end_) {
         processed_events |= (this->*dispatch_table[defer_it_->id])(deps, subs, defer_it_->data);
         defer_again_ = false;
-        if (old != current_state_[0]) {
+        bool state_changed = false;
+        for (auto i = 0u; i < regions; ++i) {
+          if (old[i] != current_state_[i]) { state_changed = true; break; }
+        }
+        if (state_changed) {
           defer_it_ = defer_.begin();
-          old = current_state_[0];
+          for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
         }
       }
       defer_processing_ = false;

--- a/test/ft/actions_defer.cpp
+++ b/test/ft/actions_defer.cpp
@@ -364,3 +364,26 @@ test defer_minimal_static_deque = [] {
   sm.process_event(event2());
   expect(sm.is(sml::X));
 };
+
+const auto dummy = sml::state<class dummy>;
+
+test defer_non_first_orthogonal_region = [] {
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *dummy  + event<event4> = X       // region 0 (dummy, never fires)
+        ,*state1 + event<event1> / defer   // region 1: defer e1
+        , state1 + event<event2> = state2
+        , state2 + event<event1> = state1
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c, sml::defer_queue<std::deque>> sm{};
+  sm.process_event(event1());  // deferred
+  sm.process_event(event2());  // state1->state2; deferred event1 fires: state2->state1
+  expect(sm.is(state1));
+};


### PR DESCRIPTION
Fixes #636.

`queue_event::dtor_impl` took `aux::byte*` then `reinterpret_cast<T*>`, which GCC flags as `-Wcast-align` when T has alignment stricter than 1 (e.g. `std::string` on some ABIs, or explicitly over-aligned types).

The storage is already aligned via `alignas(alignment)`, so the cast is safe — only the parameter type is misleading. Fix: use `void*` for the destructor function pointer and `static_cast` in both `dtor_impl` and `move_impl`.