### PR TITLE
fix lock_guard member order in thread_safe for clang-cl

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1637,9 +1637,9 @@ struct thread_safe : aux::pair<thread_safety_policy__, thread_safe<TLock>> {
   using type = thread_safe;
   constexpr auto create_lock() {
     struct lock_guard {
+      TLock &lock_;
       constexpr explicit lock_guard(TLock &lock) : lock_{lock} { lock_.lock(); }
       ~lock_guard() { lock_.unlock(); }
-      TLock &lock_;
     };
     return lock_guard{lock};
   }


### PR DESCRIPTION
`thread_safe::create_lock()` defines a local `lock_guard` struct with
`lock_` declared after the constructor and destructor that use it.
clang-cl on Windows rejects this with an error about the member being
undeclared at point of use.

Fix: move `lock_` to the top of the struct so it's declared before the
methods reference it.

Fixes #585