### PR TITLE
fix submachine state not accessible as action parameter (#659)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2292,6 +2292,21 @@ template <class... TEvents, class TEvent, class Tsm, class TDeps>
 constexpr decltype(auto) get_arg(const aux::type_wrapper<back::process<TEvents...>> &, const TEvent, Tsm &sm, TDeps &) {
   return back::process<TEvents...>{sm.process_};
 }
+// 6-parameter overloads: look in sub_sms for submachine state types (issue #659)
+// Excluded: the current SM's own type (Tsm::sm_t), which belongs in deps
+template <class T, class TEvent, class Tsm, class TDeps, class TSubs,
+          class T_ = aux::remove_const_t<aux::remove_reference_t<T>>,
+          __BOOST_SML_REQUIRES(!aux::is_same<T_, typename Tsm::sm_t>::value)>
+constexpr auto get_arg(const aux::type_wrapper<T> &, const TEvent &, Tsm &, TDeps &,
+                       TSubs &subs, int)
+    -> decltype(static_cast<T_ &>(back::sub_sm<back::sm_impl<back::sm_policy<T_>>>::get(&subs))) {
+  return static_cast<T_ &>(back::sub_sm<back::sm_impl<back::sm_policy<T_>>>::get(&subs));
+}
+template <class T, class TEvent, class Tsm, class TDeps, class TSubs>
+constexpr decltype(auto) get_arg(const aux::type_wrapper<T> &tw, const TEvent &event, Tsm &sm,
+                                 TDeps &deps, TSubs &, ...) {
+  return get_arg(tw, event, sm, deps);
+}
 template <class, class, class>
 struct call;
 template <class TEvent>
@@ -2363,27 +2378,27 @@ struct call<TEvent, aux::type_list<action_base>, TLogger> {
 template <class TEvent, class... Ts>
 struct call<TEvent, aux::type_list<Ts...>, back::no_policy> {
   template <class T, class Tsm, class TDeps, class TSubs>
-  constexpr static auto execute(T object, const TEvent &event, Tsm &sm, TDeps &deps, TSubs &) {
-    return object(get_arg(aux::type_wrapper<Ts>{}, event, sm, deps)...);
+  constexpr static auto execute(T object, const TEvent &event, Tsm &sm, TDeps &deps, TSubs &subs) {
+    return object(get_arg(aux::type_wrapper<Ts>{}, event, sm, deps, subs, 0)...);
   }
 };
 template <class TEvent, class... Ts, class TLogger>
 struct call<TEvent, aux::type_list<Ts...>, TLogger> {
   template <class T, class Tsm, class TDeps, class TSubs>
-  constexpr static auto execute(T object, const TEvent &event, Tsm &sm, TDeps &deps, TSubs &) {
-    using result_type = decltype(object(get_arg(aux::type_wrapper<Ts>{}, event, sm, deps)...));
-    return execute_impl<typename Tsm::sm_t>(aux::type_wrapper<result_type>{}, object, event, sm, deps);
+  constexpr static auto execute(T object, const TEvent &event, Tsm &sm, TDeps &deps, TSubs &subs) {
+    using result_type = decltype(object(get_arg(aux::type_wrapper<Ts>{}, event, sm, deps, subs, 0)...));
+    return execute_impl<typename Tsm::sm_t>(aux::type_wrapper<result_type>{}, object, event, sm, deps, subs);
   }
-  template <class Tsm, class T, class SM, class TDeps>
-  constexpr static auto execute_impl(const aux::type_wrapper<bool> &, T object, const TEvent &event, SM &sm, TDeps &deps) {
-    const auto result = object(get_arg(aux::type_wrapper<Ts>{}, event, sm, deps)...);
+  template <class Tsm, class T, class SM, class TDeps, class TSubs>
+  constexpr static auto execute_impl(const aux::type_wrapper<bool> &, T object, const TEvent &event, SM &sm, TDeps &deps, TSubs &subs) {
+    const auto result = object(get_arg(aux::type_wrapper<Ts>{}, event, sm, deps, subs, 0)...);
     back::policies::log_guard<Tsm>(aux::type_wrapper<TLogger>{}, deps, object, event, result);
     return result;
   }
-  template <class Tsm, class T, class SM, class TDeps>
-  constexpr static auto execute_impl(const aux::type_wrapper<void> &, T object, const TEvent &event, SM &sm, TDeps &deps) {
+  template <class Tsm, class T, class SM, class TDeps, class TSubs>
+  constexpr static auto execute_impl(const aux::type_wrapper<void> &, T object, const TEvent &event, SM &sm, TDeps &deps, TSubs &subs) {
     back::policies::log_action<Tsm>(aux::type_wrapper<TLogger>{}, deps, object, event);
-    object(get_arg(aux::type_wrapper<Ts>{}, event, sm, deps)...);
+    object(get_arg(aux::type_wrapper<Ts>{}, event, sm, deps, subs, 0)...);
   }
 };
 template <class... Ts>

--- a/test/ft/composite.cpp
+++ b/test/ft/composite.cpp
@@ -1160,3 +1160,43 @@ test composite_virtual_base = [] {
   sm.process_event(virtual_base_ev{});
   expect(sm.is(sml::X));
 };
+
+// issue #659: state data must persist when the state is a submachine
+test submachine_state_data_persistence = [] {
+  struct start_e { int amount = 0; };
+  struct increment_e {};
+
+  struct counter_sub {
+    auto operator()() noexcept {
+      using namespace sml;
+      const auto counting = state<class counting>;
+      return make_transition_table(
+         *counting + event<increment_e> / [this] { count += increment_by; }
+      );
+    }
+    int increment_by = 0;
+    int count = 0;
+  };
+
+  struct outer {
+    auto operator()() noexcept {
+      using namespace sml;
+      return make_transition_table(
+         *state<class outer_idle> + event<start_e> / [](counter_sub &cs, const start_e &e) { cs.increment_by = e.amount; }
+              = state<counter_sub>
+      );
+    }
+  };
+
+  counter_sub cs_dep{};
+  sml::sm<outer> sm{cs_dep};
+
+  sm.process_event(start_e{5});
+  sm.process_event(increment_e{});
+  sm.process_event(increment_e{});
+  sm.process_event(increment_e{});
+
+  counter_sub &cs = sm;  // access the live submachine state via sm
+  expect(5 == cs.increment_by);
+  expect(15 == cs.count);
+};


### PR DESCRIPTION
## Problem

Actions that take a submachine struct by reference — e.g.
`[](MySubSM &s, const StartEvent &e) { s.value = e.value; }` — received
a stale copy from `deps_` instead of the live state stored in `sub_sms_`.

`sm_impl<sm_policy<T, ...>>` inherits from `T` and **is** the authoritative
state of a submachine; `deps_` holds a separate copy that the submachine
never reads.

## Root cause (identified by reporter)

`get_arg(type_wrapper<T>, …, deps)` only looks in `deps_`. Submachine types
are not stored there as live objects; they are stored inside
`sm_impl<sm_policy<T, …>>` in `sub_sms_`.

## Fix

Two new 6-parameter `get_arg` overloads (int/`…` priority for disambiguation):

1. **Higher priority** – when `T_` (bare type after stripping cv/ref) is
   present in `sub_sms_` *and* is not the current SM's own type
   (`Tsm::sm_t`), retrieve it via
   `sub_sm<sm_impl<sm_policy<T_>>>::get(&subs)` and cast to `T_ &`.
2. **Fallback** – delegate to the existing 4-parameter `get_arg` (deps path).

`call::execute` (no-policy and logger variants) now forward `subs` to
`get_arg`; the logger path also threads `subs` through `execute_impl` so
the logged path is consistent.

The `Tsm::sm_t` exclusion preserves existing behaviour for top-level SM
member-function callbacks (e.g. `&c::action` where `c` is the outer SM).

## Test

`submachine_state_data_persistence` added to `test/ft/composite.cpp`:
a programmable counter submachine whose increment step is set from a
transition action in the outer SM. Verified the test fails before the fix
and passes after.

Closes #659