### PR TITLE
fix uninitialized array in constexpr context (GCC 14)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1806,7 +1806,7 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
     const auto lock = thread_safety_.create_lock();
     (void)lock;
     bool changed = false;
-    state_t old[regions];
+    state_t old[regions]{};
     for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
     bool handled = process_internal_events(event, deps, subs);
     bool queued_handled = true;
@@ -2017,7 +2017,7 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
       defer_again_ = false;
       defer_it_ = defer_.begin();
       defer_end_ = defer_.end();
-      state_t old[regions];
+      state_t old[regions]{};
       for (auto i = 0u; i < regions; ++i) old[i] = current_state_[i];
       while (defer_it_ != defer_end_) {
         processed_events |= (this->*dispatch_table[defer_it_->id])(deps, subs, defer_it_->data);

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -27,6 +27,12 @@ add_test(test_wrap test_wrap)
 
 add_executable(test_deep_sm deep_sm.cpp)
 
+add_executable(test_issue_639_repro issue_639_repro.cpp)
+if(IS_COMPILER_OPTION_GCC_LIKE)
+  target_compile_options(test_issue_639_repro PRIVATE "-ftemplate-depth=100")
+endif()
+add_test(test_issue_639_repro test_issue_639_repro)
+
 add_executable(test_di di.cpp)
 add_test(test_di test_di)
 


### PR DESCRIPTION
## Problem

Two `state_t old[regions]` declarations in `sm_impl::process_event` and the deferred-event dispatch were uninitialized at the point of declaration. GCC 14 enforces that constexpr functions cannot contain uninitialized local variables, causing the `constexpr_sm` test to fail with:

```
error: uninitialized variable 'old' in 'constexpr' context
state_t old[regions];
```

## Fix

Zero-initialize both occurrences with `{}`:
```cpp
state_t old[regions]{};  // state_t is unsigned char or unsigned short
```

`state_t` is always an integer type (`unsigned char` or `unsigned short`), so `{}` gives correct zero-initialization with no overhead.

## Also included

Adds `issue_639_repro.cpp` to the CMake test configuration with `-ftemplate-depth=100`, so the template depth regression test from issue #639 runs in CI (it was previously only present in the Makefile).

Closes the GCC 14 constexpr failure visible when running `make test CXX=g++ CXXSTD=c++17` locally.