### PR TITLE
fix double-pop crash in process_queued_events (issue #465)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -946,6 +946,7 @@ class queue_event {
   constexpr queue_event() : dtor(nullptr) {}
   constexpr queue_event(queue_event &&other) : id(other.id), dtor(other.dtor), move(other.move) {
     move(data, static_cast<queue_event &&>(other));
+    other.dtor = nullptr;  // prevent double-destruction of the moved-from payload (#279)
   }
   constexpr queue_event &operator=(queue_event &&other) {
     if (dtor != nullptr) {
@@ -955,6 +956,7 @@ class queue_event {
     dtor = other.dtor;
     move = other.move;
     move(data, static_cast<queue_event &&>(other));
+    other.dtor = nullptr;  // prevent double-destruction of the moved-from payload (#279)
     return *this;
   }
   constexpr queue_event(const queue_event &) = delete;
@@ -2057,8 +2059,9 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
         &sm_impl::process_event_no_queue<TDeps, TSubs, TEvents>...};
     bool wasnt_empty = !process_.empty();
     while (!process_.empty()) {
-      queued_handled &= (this->*dispatch_table[process_.front().id])(deps, subs, process_.front().data);
-      process_.pop();
+      typename process_t::value_type event{static_cast<typename process_t::value_type &&>(process_.front())};
+      process_.pop();  // pop before dispatch so re-entrant calls see an advanced queue (#465)
+      queued_handled &= (this->*dispatch_table[event.id])(deps, subs, event.data);
     }
     return wasnt_empty;
   }

--- a/test/ft/actions_process.cpp
+++ b/test/ft/actions_process.cpp
@@ -25,6 +25,33 @@ const auto s1 = sml::state<class s1>;
 const auto s2 = sml::state<class s2>;
 const auto s3 = sml::state<class s3>;
 
+// Regression fixture for issue #465.
+// Defined at file scope so sm<c465> can be named without circular instantiation:
+// the action lambda calls do_reentrant (a plain function pointer set in the test),
+// which in turn calls sm.process_event — without any sm<c465> reference in operator().
+struct c465 {
+  bool (*do_reentrant)(void*) = nullptr;  // filled in by the test after sm construction
+  void* sm_ptr = nullptr;
+  int e2_action_count = 0;
+  bool first_dispatch = true;
+
+  auto operator()() noexcept {
+    using namespace sml;
+    // clang-format off
+    return make_transition_table(
+        *state<class s1_465> + event<e1> / process(e2{}) = state<class s2_465>
+      , state<class s2_465> + event<e2> / [this] {
+            ++e2_action_count;
+            if (first_dispatch) {
+              first_dispatch = false;
+              if (do_reentrant) do_reentrant(sm_ptr);  // re-entrant sm.process_event(e3)
+            }
+          } = sml::X
+    );
+    // clang-format on
+  }
+};
+
 test process_event = [] {
   struct c {
     auto operator()() {
@@ -367,4 +394,29 @@ test queue_process_events_static_queue = [] {
   expect(0 == c_.calls[0]);
   expect(1 == c_.calls[1]);
   expect(2 == c_.calls[2]);
+};
+
+// Issue #465: process_queued_events dispatched the front event before popping it.
+// A re-entrant sm.process_event() call inside the action saw the same event still at
+// the front, dispatched it again (double action call), popped it, then the outer loop
+// called pop() on an empty queue — undefined behaviour / crash.
+// c465 is defined at file scope (above) to avoid circular sm<c465> instantiation.
+test process_queue_no_double_pop_on_reentrant_process_event = [] {
+  using sm465_t = sml::sm<c465, sml::process_queue<std::queue>>;
+
+  sm465_t sm{};
+  c465& c_ = sm;
+  c_.sm_ptr = &sm;
+  // Captureless lambda → function pointer: calls sm.process_event(e3) re-entrantly.
+  // e3 has no handler; its sole job is triggering a re-entrant process_queued_events.
+  c_.do_reentrant = +[](void* ptr) -> bool {
+    return static_cast<sm465_t*>(ptr)->process_event(e3{});
+  };
+
+  sm.process_event(e1{});  // queues e2; process_queued_events then dispatches it
+
+  // With the bug: e2 action fires twice (count==2) and outer pop() on empty queue is UB.
+  // With the fix: e2 action fires exactly once.
+  expect(1 == c_.e2_action_count);
+  expect(sm.is(sml::X));
 };


### PR DESCRIPTION
## Problem

`process_queued_events` dispatched the front event **before** removing it from the queue.
If an action called `sm.process_event()` re-entrantly (e.g., from an ASIO callback or any other re-entrant call), the inner `process_queued_events` saw the same event still at the front, processed it a second time, then popped it.
When control returned to the outer loop, it called `pop()` on an already-empty queue — undefined behaviour / crash.

**Bug trace (re-entrant case):**
1. Action calls `back::process(e2{})` → e2 pushed to `process_`
2. `process_queued_events` enters the while loop; front = e2 (**not yet popped**)
3. Dispatches e2's action; the action calls `sm.process_event(e3)` re-entrantly
4. The inner `process_queued_events` sees e2 at front again → dispatches e2 a **second** time, then pops it
5. Outer loop calls `process_.pop()` on the now-empty queue → **UB / crash**

Related issues: #395 (same root in ASIO context), #552 (thread-safety manifestation).

## Fixes

### 1. Pop before dispatch — resolves #465

Move the front `queue_event` into a local variable, pop the (now moved-from) element, then invoke the dispatch:

```cpp
typename process_t::value_type event{static_cast<typename process_t::value_type&&>(process_.front())};
process_.pop();  // pop before dispatch so re-entrant calls see an advanced queue
queued_handled &= (this->*dispatch_table[event.id])(deps, subs, event.data);
```

Re-entrant calls see an already-advanced queue and cannot observe the in-flight event.

### 2. Null `other.dtor` after move in `queue_event` — resolves #279

The `queue_event` move constructor and move-assign transferred ownership of the payload but left `other.dtor` set.
Destroying the moved-from `queue_event` (as `pop()` does in fix 1) then called `dtor()` on already-moved-from storage — double-destruction.
Zeroing `other.dtor` after the move makes the moved-from destructor a no-op, which is required for fix 1 to be sound for non-trivially-destructible event types.

These two fixes are co-located because fix 2 is a soundness prerequisite for fix 1.

## Regression test

Added `process_queue_no_double_pop_on_reentrant_process_event` to `test/ft/actions_process.cpp`:
- SM transitions `s1 --e1--> s2` with `process(e2{})` as action
- `s2 --e2` action increments a counter and calls `sm.process_event(e3)` re-entrantly (e3 has no handler)
- After `sm.process_event(e1)`, asserts the counter is **1** (not 2), and the SM is in state `X`

With the bug: counter == 2 and `pop()` on empty queue is UB.
With the fix: counter == 1, SM ends in `X`, no UB.

Closes #465
Also fixes #279 (move semantics)