### PR TITLE
fix -Wextra-semi warning when BOOST_SML_CFG_DISABLE_MIN_SIZE is set (#519)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -30,7 +30,7 @@
 #if !defined(BOOST_SML_CFG_DISABLE_MIN_SIZE)
 #define __BOOST_SML_ZERO_SIZE_ARRAY(...) __VA_ARGS__ _[0]
 #else
-#define __BOOST_SML_ZERO_SIZE_ARRAY(...)
+#define __BOOST_SML_ZERO_SIZE_ARRAY(...) static_assert(true)
 #endif
 #define __BOOST_SML_ZERO_SIZE_ARRAY_CREATE(...)
 #define __BOOST_SML_TEMPLATE_KEYWORD template
@@ -48,7 +48,7 @@
 #if !defined(BOOST_SML_CFG_DISABLE_MIN_SIZE)
 #define __BOOST_SML_ZERO_SIZE_ARRAY(...) __VA_ARGS__ _[0]{}
 #else
-#define __BOOST_SML_ZERO_SIZE_ARRAY(...)
+#define __BOOST_SML_ZERO_SIZE_ARRAY(...) static_assert(true)
 #endif
 #define __BOOST_SML_ZERO_SIZE_ARRAY_CREATE(...) __VA_ARGS__ ? __VA_ARGS__ : 1
 #define __BOOST_SML_TEMPLATE_KEYWORD template
@@ -63,7 +63,7 @@
 #define __has_builtin__make_integer_seq(...) 1
 #define __BOOST_SML_UNUSED
 #define __BOOST_SML_VT_INIT
-#define __BOOST_SML_ZERO_SIZE_ARRAY(...)
+#define __BOOST_SML_ZERO_SIZE_ARRAY(...) static_assert(true)
 #define __BOOST_SML_ZERO_SIZE_ARRAY_CREATE(...) __VA_ARGS__ ? __VA_ARGS__ : 1
 #if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER >= 1910  // MSVC 2017
 #define __BOOST_SML_TEMPLATE_KEYWORD template
@@ -81,7 +81,7 @@
 #define __BOOST_SML_UNUSED __attribute__((unused))
 #define __BOOST_SML_VT_INIT \
   {}
-#define __BOOST_SML_ZERO_SIZE_ARRAY(...)
+#define __BOOST_SML_ZERO_SIZE_ARRAY(...) static_assert(true)
 #define __BOOST_SML_ZERO_SIZE_ARRAY_CREATE(...) __VA_ARGS__ ? __VA_ARGS__ : 1
 #define __BOOST_SML_TEMPLATE_KEYWORD template
 #endif


### PR DESCRIPTION
## Problem

When `BOOST_SML_CFG_DISABLE_MIN_SIZE` is defined, `__BOOST_SML_ZERO_SIZE_ARRAY` expands to nothing. The ten call sites in struct bodies all end with a semicolon:

```cpp
struct pool_type_impl {
    __BOOST_SML_ZERO_SIZE_ARRAY(byte);   // expands to bare ';'
    ...
};
```

The preprocessed output contains a bare `;` inside a struct definition. Clang 14+ (and any build with `-Werror -Wextra-semi`) rejects this with:

```
error: extra ';' after member declaration [-Werror,-Wextra-semi]
```

## Fix

Expand the empty branches to `static_assert(true)` instead of nothing:

```cpp
#define __BOOST_SML_ZERO_SIZE_ARRAY(...) static_assert(true)
```

`static_assert(true);` is a well-formed member-declaration in C++17, has no run-time effect, and consumes the trailing semicolon so no extra `;` appears in the struct body. Applied consistently to all four compiler branches (Clang, GCC, MSVC, IAR) that previously produced the empty expansion.

## Verification

```
g++ -std=c++17 -DBOOST_SML_CFG_DISABLE_MIN_SIZE -Wextra-semi -Werror ...
```

Compiles cleanly. Full test suite passes with no regressions.

Fixes #519.