### PR TITLE
fix null deref when pointer dependency passed as lvalue to sm ctor (#485)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -725,6 +725,17 @@ template <class T>
 constexpr T *try_get(const pool_type<T *> *object) {
   return object->value;
 }
+// When a pointer dep is passed as an lvalue the forwarding constructor wraps
+// it in T*& (reference-to-pointer).  Strip the reference so the pool init
+// constructor can find the stored value. (#485)
+template <class T>
+constexpr T *try_get(const pool_type<T *&> *object) {
+  return object->value;
+}
+template <class T>
+constexpr const T *try_get(const pool_type<const T *&> *object) {
+  return object->value;
+}
 template <class T, class TPool>
 constexpr bool would_instantiate_missing_ctor_parameter() {
   return is_same<missing_ctor_parameter<T>, decltype(try_get<T>(aux::declval<TPool>()))>::value;

--- a/test/ft/dependencies.cpp
+++ b/test/ft/dependencies.cpp
@@ -396,3 +396,51 @@ test ref_dep_copy_from_pool_not_dangling = [] {
   // verifying the dep reference is valid (not dangling).
   sm.process_event(e2{});
 };
+
+// Issue #485: passing a pointer dependency as an lvalue caused the SM to store
+// nullptr instead of the actual pointer.  Root cause: forwarding reference
+// deduction wraps a T* lvalue as T*&; the pool init constructor's try_get
+// lookup had no overload for pool_type<T*&>*, so it fell through to the
+// missing_ctor_parameter catch-all which returned nullptr.
+// Fix: add try_get overloads for reference-to-pointer types (T*& and const T*&).
+struct dep485 {
+  int val = 42;
+};
+
+test pointer_dep_lvalue_not_null = [] {
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // action takes non-const pointer: Dep*
+      auto action = [](dep485* d) { expect(d != nullptr); expect(42 == d->val); };
+      // clang-format off
+      return make_transition_table(*idle + event<e1> / action = X);
+      // clang-format on
+    }
+  };
+
+  dep485 dep;
+  dep485* ptr = &dep;  // lvalue pointer — was getting stored as nullptr before the fix
+  sml::sm<c> sm{ptr};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test const_pointer_dep_lvalue_not_null = [] {
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // action takes const pointer: const Dep*
+      auto action = [](const dep485* d) { expect(d != nullptr); expect(42 == d->val); };
+      // clang-format off
+      return make_transition_table(*idle + event<e1> / action = X);
+      // clang-format on
+    }
+  };
+
+  dep485 dep;
+  dep485* ptr = &dep;  // non-const Dep* lvalue: should be implicitly convertible to const Dep*
+  sml::sm<c> sm{ptr};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};


### PR DESCRIPTION
## Problem

When a `T*` dependency is passed as an **lvalue** to `sm<M>{ptr}`, C++ forwarding reference deduction binds `TDeps` as `T*&` (reference-to-pointer). The pool init constructor then builds an input pool of type `pool<T*&>`.

The stripping logic in the pool init constructor:

```cpp
try_get<remove_const_t<remove_reference_t<remove_pointer_t<Ts>>>>(&p)
```

strips `T*` → `T`, then calls `try_get<T>` on `pool<T*&>`. The existing `try_get` overloads only match `pool_type<T*>` and `pool_type<const T*>` — there is no overload for `pool_type<T*&>`, so the call falls through to the variadic catch-all and returns `missing_ctor_parameter<T>{}`. That silently converts to a null pointer. Every action or guard that takes a pointer dependency then receives `nullptr` and dereferences it → crash / assertion failure.

## Reproduction

```cpp
struct Dep { int val = 42; };
struct M {
  auto operator()() noexcept {
    using namespace sml;
    // action takes const Dep* — was receiving nullptr
    auto action = [](const Dep* d) { assert(d != nullptr); };
    return make_transition_table(*"s1"_s + event<e1>{} / action = X);
  }
};
Dep dep;
Dep* ptr = &dep;          // lvalue pointer
sml::sm<M> sm{ptr};       // TDeps deduced as Dep*& — bug triggers here
sm.process_event(e1{});   // assertion fires
```

The same bug affects `Dep*` (non-const) action parameters.

## Fix

Add two `try_get` overloads that match reference-to-pointer pool slots:

```cpp
template <class T>
constexpr T *try_get(const pool_type<T *&> *object) {
  return object->value;
}
template <class T>
constexpr const T *try_get(const pool_type<const T *&> *object) {
  return object->value;
}
```

These extract the stored pointer from the reference-wrapping slot. The `T&` (reference dependency) case already worked correctly and is unaffected.

## Tests

Regression tests added in `test/ft/dependencies.cpp`:
- `pointer_dep_lvalue_not_null` — action takes `Dep*`, SM constructed with `Dep*` lvalue
- `const_pointer_dep_lvalue_not_null` — action takes `const Dep*`, SM constructed with `Dep*` lvalue

Existing test suite passes without modification.

Fixes #485.