### PR TITLE
fix dangling reference in pool_type_impl<T&> init constructor (#504)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -649,8 +649,13 @@ struct pool_type_impl<T &, aux::enable_if_t<aux::is_constructible<T>::value && a
   constexpr explicit pool_type_impl(T &value) : value{value} {}
   template <class TObject>
   constexpr explicit pool_type_impl(TObject value) : value_{value}, value{value_} {}
+  // Copy-construct from another pool: extract T from the source pool into the
+  // local backing store, then bind the reference member to it.  The old code
+  // used ': value(i, object)' which is a comma expression — it evaluated
+  // (i, object) and bound 'value' (T&) directly to the pool parameter
+  // 'object', leaving a dangling reference once the constructor returned. (#504)
   template <class TObject>
-  constexpr pool_type_impl(const init &i, const TObject &object) : value(i, object) {}
+  constexpr pool_type_impl(const init &, const TObject &object) : value_{try_get<T>(&object)}, value{value_} {}
   T value_{};
   T &value;
 };

--- a/test/ft/dependencies.cpp
+++ b/test/ft/dependencies.cpp
@@ -353,3 +353,45 @@ test dependencies_multiple_subs = [] {
   }
 };
 #endif
+
+// Issue #504: pool_type_impl<T&>'s (init, object) constructor used a comma
+// expression ': value(i, object)' to "initialize" a reference member.
+// (i, object) is the C++ comma operator — it evaluates i, discards the result,
+// then evaluates object, whose value becomes the initializer.  For a T& member
+// this bound the reference to the 'object' function parameter, which is a
+// dangling reference after the constructor returns.
+// Fix: initialize the backing store value_ via try_get, then bind value to value_.
+// This test exercises the pool(const pool<TArgs...>&) copy-constructor path that
+// instantiates pool_type_impl<T&>(const init&, const TObject&).
+struct dep504 {
+  int val = 99;
+};
+
+test ref_dep_copy_from_pool_not_dangling = [] {
+  // SM with a reference dep (dep504&) and a sub-SM so that the
+  // pool(const pool<TArgs...>&) path is exercised during sm construction.
+  struct sub504 {
+    auto operator()() noexcept {
+      using namespace sml;
+      auto check = [](dep504& d) { expect(99 == d.val); };
+      // clang-format off
+      return make_transition_table(*idle + event<e2> / check = X);
+      // clang-format on
+    }
+  };
+
+  struct top504 {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(*idle + event<e1> = sml::state<sub504>);
+      // clang-format on
+    }
+  };
+
+  dep504 dep;
+  sml::sm<top504> sm{dep};
+  sm.process_event(e1{});
+  sm.process_event(e2{});
+  expect(sm.is<sml::state<sub504>>(sml::X));
+};


### PR DESCRIPTION
## Problem

The `pool_type_impl<T&>` specialisation (active under `BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS`) contains a copy-paste bug in its `(init, object)` constructor:

```cpp
constexpr pool_type_impl(const init &i, const TObject &object)
  : value(i, object) {}  // BUG
```

`value` is a `T&` (reference) member. In a member-initialiser list, `value(i, object)` for a reference type does **not** call a two-argument constructor — it applies the **C++ comma operator**: evaluates `i` (discards result), then evaluates `object`, and binds `value` to the result.

`object` is a function parameter (`const TObject&`) that goes out of scope once the constructor returns, leaving `value` as a **dangling reference**. Any subsequent access through `value` is undefined behaviour.

## Fix

Initialise the backing-store member `value_` by extracting `T` from the source pool via `try_get`, then bind the reference member `value` to `value_`:

```cpp
constexpr pool_type_impl(const init &, const TObject &object)
  : value_{try_get<T>(&object)}, value{value_} {}
```

This stores a local copy in `value_` and keeps the reference valid for the lifetime of the `pool_type_impl` object — matching the pattern already used in the other constructors of this specialisation.

## Test

Regression test `ref_dep_copy_from_pool_not_dangling` added in `test/ft/dependencies.cpp`: an SM with a reference dep (`dep504&`) and a sub-state machine exercises the `pool(const pool<TArgs...>&)` constructor path that instantiates the fixed constructor.

Fixes #504.