### PR TITLE
fix process_queue<std::queue> compile error on GCC 9/Clang 10 (issue #441)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1039,7 +1039,7 @@ struct queue_handler : queue_event_call<TEvents>... {
  private:
   template <class TQueue, class TEvent>
   constexpr static auto push_impl(void *queue, const TEvent &event) {
-    static_cast<TQueue *>(queue)->push(event);
+    static_cast<TQueue *>(queue)->push(typename TQueue::value_type{event});
   }
   void *queue_{};
 };
@@ -1057,7 +1057,7 @@ struct deque_handler : queue_event_call<TEvents>... {
  private:
   template <class TDeque, class TEvent>
   constexpr static auto push_impl(void *deque, const TEvent &event) {
-    static_cast<TDeque *>(deque)->push_back(event);
+    static_cast<TDeque *>(deque)->push_back(typename TDeque::value_type{event});
   }
   void *deque_{};
 };

--- a/test/ft/actions_process.cpp
+++ b/test/ft/actions_process.cpp
@@ -480,3 +480,38 @@ test process_queue_anonymous_transitions_between_queued_events = [] {
   // With the fix: all 6 events fire (initial e542{5} + 5 recursive).
   expect(6 == c_.fires);
 };
+
+// Issue #441: using process_queue<std::queue> failed to compile on GCC 9/10 and
+// Clang 10/11 because push_impl passed a const lvalue to std::queue::push, causing
+// overload resolution to select push(const value_type&) instead of push(value_type&&).
+// Since queue_event's copy constructor is deleted this produced a hard compile error.
+// Fix: explicitly construct the value_type rvalue so push(value_type&&) is always chosen.
+test process_queue_std_queue_compiles_and_works = [] {
+  struct c441 {
+    int processed = 0;
+
+    auto operator()() noexcept {
+      using namespace sml;
+      auto enqueue = [this](back::process<e2> proc) {
+        proc(e2{});
+        ++processed;
+      };
+      auto finish = [this] { ++processed; };
+      // clang-format off
+      return make_transition_table(
+          *idle + event<e1> / enqueue = s1
+        ,  s1   + event<e2> / finish  = X
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c441, sml::process_queue<std::queue>> sm{};
+  c441 &c_ = sm;
+
+  sm.process_event(e1{});   // enqueues e2, transitions idle→s1
+  sm.process_event(e2{});   // drains the queue: fires finish, transitions s1→X
+
+  expect(2 == c_.processed);
+  expect(sm.is(sml::X));
+};


### PR DESCRIPTION
Fixes #441.

## Root cause

`push_impl` in `queue_handler` and `deque_handler` passed the event as a const lvalue to `push`/`push_back`:

```cpp
static_cast<TQueue *>(queue)->push(event);  // event is const TEvent&
```

On GCC 9/10 and Clang 10/11, overload resolution could select `push(const value_type&)` instead of `push(value_type&&)` when an implicit conversion was needed to create a `queue_event` temporary.  Since `queue_event`'s copy constructor is deleted (it is move-only), this produced a hard compile error.

## Fix

Explicitly construct a `value_type` rvalue so the move overload is unambiguously selected on all compiler versions:

```cpp
static_cast<TQueue *>(queue)->push(typename TQueue::value_type{event});
```

Same fix applied to `deque_handler::push_impl` (`push_back`).

## Test

Added `process_queue_std_queue_compiles_and_works` to `test/ft/actions_process.cpp` — uses `sml::sm<..., sml::process_queue<std::queue>>` with a queued `e2` event triggered from an `e1` action.