### PR TITLE
document operator, limitation for two raw MFP actions and show wrap() fix (issue #389)

### DIFF
--- a/example/actions_guards.cpp
+++ b/example/actions_guards.cpp
@@ -52,7 +52,9 @@ struct actions_guards {
       , "s2"_s + event<e3> [ guard1 && ![] { return false;} ] / (action1, action2{}) = "s3"_s
       , "s3"_s + event<e4> [ !guard1 || guard2 ] / (action1, [] { std::cout << "action3" << std::endl; }) = "s4"_s
       , "s3"_s + event<e4> [ guard1 ] / ([] { std::cout << "action4" << std::endl; }, [this] { action4(); } ) = "s5"_s
-      , "s5"_s + event<e5> [ &self::guard3 ] / &self::action5 = X
+      // Two member-function-pointer actions: wrap() the first so operator, fires correctly.
+      // (&self::action4, &self::action5) would silently run only action5 (built-in comma).
+      , "s5"_s + event<e5> [ &self::guard3 ] / (wrap(&self::action4), &self::action5) = X
     );
     // clang-format on
   }

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2555,6 +2555,13 @@ template <class T1, class T2, __BOOST_SML_REQUIRES(concepts::callable<bool, T1>:
 constexpr auto operator||(const T1 &t1, const T2 &t2) {
   return front::or_<aux::zero_wrapper<T1>, aux::zero_wrapper<T2>>(aux::zero_wrapper<T1>{t1}, aux::zero_wrapper<T2>{t2});
 }
+// Action sequencing: / (a1, a2) or / (a1, a2, a3, ...)
+// At least one operand must be a class type (lambda, functor, or sml::wrap(mfp)) for
+// this user-defined operator, to be selected over the built-in comma operator.
+// Two raw member-function pointers, e.g. / (&C::a, &C::b), are both pointer types
+// (not class types), so the built-in comma is selected instead and only the last
+// action runs.  Wrap the first pointer with sml::wrap() to fix:
+//   / (sml::wrap(&C::a), &C::b)   -- correct: both a and b execute
 template <class T1, class T2, __BOOST_SML_REQUIRES(concepts::callable<void, T1>::value &&concepts::callable<void, T2>::value)>
 constexpr auto operator,(const T1 &t1, const T2 &t2) {
   return front::seq_<aux::zero_wrapper<T1>, aux::zero_wrapper<T2>>(aux::zero_wrapper<T1>{t1}, aux::zero_wrapper<T2>{t2});

--- a/test/ft/transition_table.cpp
+++ b/test/ft/transition_table.cpp
@@ -214,3 +214,34 @@ test transition_table_types = [] {
   float f = 12.0;
   sml::sm<c> sm{f, 42, 87.0, 0.0f};
 };
+
+// Issue #389: two member-function-pointer actions combined with operator,
+// silently ran only the last action because raw MFP types are not class types —
+// the built-in comma operator was selected instead of the user-defined one.
+// Fix: wrap the first MFP with sml::wrap() so it becomes a class type and the
+// overloaded operator, is considered by overload resolution.
+test member_functions_two_mfp_actions_with_wrap = [] {
+  struct c {
+    using self = c;
+
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         // wrap() the first MFP so operator, sees a class type and sequences both.
+         *idle + event<e1> / (wrap(&self::action_a), &self::action_b) = X
+      );
+      // clang-format on
+    }
+
+    void action_a() { ++calls; }
+    void action_b() { ++calls; }
+    int calls = 0;
+  };
+
+  c c_{};
+  sml::sm<c> sm{c_};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+  expect(2 == c_.calls);  // both action_a and action_b must have run
+};


### PR DESCRIPTION
Fixes #389.

## Root cause

`/ (&C::action_a, &C::action_b)` uses the C++ built-in comma operator instead of the library's action-sequencing `operator,`.  Raw member-function pointers are pointer types, not class types.  The C++ standard only allows user-defined `operator,` to be selected when at least one operand is a class or enum type, so the built-in comma always wins for two raw MFPs — silently discarding the first action.

This is a C++ language constraint that cannot be removed at the library level.

## Workaround: `sml::wrap()` the first MFP

`sml::wrap()` returns a `zero_wrapper<MFP>`, which is a class type.  That satisfies the requirement and the user-defined `operator,` is selected:

```cpp
// broken — only action_b runs
/ (&C::action_a, &C::action_b)

// correct — both action_a and action_b run
/ (sml::wrap(&C::action_a), &C::action_b)
```

Subsequent actions in the list (additional MFPs, lambdas, functors) chain correctly from there without extra `wrap()` calls, because each `operator,` already produces a class-typed `seq_` result.

## Changes

- **`include/boost/sml.hpp`**: add a comment above the global `operator,` overload explaining the language constraint and the `wrap()` workaround.
- **`example/actions_guards.cpp`**: replace the single-MFP action on the `s5` transition with `(wrap(&self::action4), &self::action5)` to demonstrate two-MFP sequencing.
- **`test/ft/transition_table.cpp`**: add `member_functions_two_mfp_actions_with_wrap` — verifies that both actions run when the first MFP is wrapped.