### PR TITLE
fix: allow final classes as SM deps and SM classes (#483)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -181,8 +181,11 @@ template <class T, class U>
 struct is_empty_base : T {
   U _;
 };
-template <class T>
+template <class T, class = void>
 struct is_empty : aux::integral_constant<bool, sizeof(is_empty_base<T, none_type>) == sizeof(none_type)> {};
+// Specialisation: final classes cannot be used as base; treat them as non-empty. (#483)
+template <class T>
+struct is_empty<T, aux::enable_if_t<bool(__is_final(T))>> : aux::false_type {};
 template <class>
 struct function_traits;
 template <class R, class... TArgs>
@@ -1675,7 +1678,8 @@ struct should_not_instantiate_statemachine_class
 
 template <class Tsm>
 struct should_not_subclass_statemachine_class
-    : integral_constant<bool, is_empty<typename Tsm::sm>::value || should_not_instantiate_statemachine_class<Tsm>::value> {};
+    : integral_constant<bool, is_empty<typename Tsm::sm>::value || should_not_instantiate_statemachine_class<Tsm>::value ||
+                                  bool(__is_final(typename Tsm::sm))> {};
 } // namespace aux
 
 namespace back {

--- a/test/ft/dependencies.cpp
+++ b/test/ft/dependencies.cpp
@@ -444,3 +444,49 @@ test const_pointer_dep_lvalue_not_null = [] {
   sm.process_event(e1{});
   expect(sm.is(sml::X));
 };
+
+// Issue #483: dependencies (and SM classes themselves) declared `final` failed
+// to compile because `is_empty_base<T>` tried to inherit from T, and `sm_impl`
+// tried to subclass the SM class.
+// Fix (is_empty): add a partial specialisation guarded by __is_final(T) that
+//   reports false without ever instantiating is_empty_base<T>.
+// Fix (sm_impl): extend should_not_subclass_statemachine_class to also return
+//   true for final SM classes, routing them through the composition path.
+
+struct final_dep483 final {
+  int val = 99;
+};
+
+test final_dependency_type_compiles = [] {
+  // A dependency type declared `final` must be usable as an SM dependency.
+  struct c483dep {
+    auto operator()() noexcept {
+      using namespace sml;
+      auto action = [](final_dep483& d) { expect(99 == d.val); };
+      // clang-format off
+      return make_transition_table(*idle + event<e1> / action = X);
+      // clang-format on
+    }
+  };
+
+  final_dep483 dep;
+  sml::sm<c483dep> sm{dep};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test final_sm_class_compiles = [] {
+  // An SM class declared `final` must work via the composition path.
+  struct final_sm483 final {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(*idle + event<e2> = X);
+      // clang-format on
+    }
+  };
+
+  sml::sm<final_sm483> sm;
+  sm.process_event(e2{});
+  expect(sm.is(sml::X));
+};


### PR DESCRIPTION
## Problem

Closes #483.

Types declared `final` cannot be used either as SM dependencies or as the SM class itself.
The compiler rejects the code because SML internally tries to inherit from the type in two places.

## Root Causes & Fixes

### 1. `is_empty<T>` — `is_empty_base<T>` inherits from `T`

```cpp
template <class T, class U>
struct is_empty_base : T { U _; };  // ← fails when T is final
```

Fix: add a partial specialisation guarded by `__is_final(T)` that inherits from `false_type` instead, so `is_empty_base<T>` is never instantiated for final types.

```cpp
template <class T, class = void>
struct is_empty : aux::integral_constant<bool, sizeof(is_empty_base<T, none_type>) == sizeof(none_type)> {};
// Specialisation: final classes cannot be used as base; treat them as non-empty. (#483)
template <class T>
struct is_empty<T, aux::enable_if_t<bool(__is_final(T))>> : aux::false_type {};
```

### 2. `sm_impl<Tsm> : Tsm::sm` — `sm_impl` inherits from the SM class

```cpp
struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<Tsm>::value,
                                     aux::none_type, typename Tsm::sm> {  // ← fails when sm is final
```

`should_not_subclass_statemachine_class` previously only returned `true` for empty SM classes (EBO) or when the `dont_instantiate_statemachine_class` policy was set.

Fix: extend the predicate to also return `true` when `__is_final(Tsm::sm)` is true.  This routes final SM classes through the existing composition path (`try_get_without_instantiating`) which calls `operator()` on the SM object without requiring inheritance.

```cpp
struct should_not_subclass_statemachine_class
    : integral_constant<bool, is_empty<typename Tsm::sm>::value ||
                              should_not_instantiate_statemachine_class<Tsm>::value ||
                              bool(__is_final(typename Tsm::sm))> {};
```

## Notes

`__is_final` is a compiler builtin available on GCC, Clang, and MSVC — used here consistently with `__is_base_of` already present in the same header.

## Tests

Two regression tests added to `test/ft/dependencies.cpp`:
- `final_dependency_type_compiles` — final dep type used in an action lambda  
- `final_sm_class_compiles` — SM class itself declared final