### PR TITLE
fix: guard taking const State& now sees live pool state (issue #530)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2371,6 +2371,21 @@ template <class... TEvents, class TEvent, class Tsm, class TDeps>
 constexpr decltype(auto) get_arg(const aux::type_wrapper<back::process<TEvents...>> &, const TEvent, Tsm &sm, TDeps &) {
   return back::process<TEvents...>{sm.process_};
 }
+// For const lvalue-ref dep parameters (`const State &`): look up the non-const
+// `State &` pool slot instead of a separate `const State &` slot.
+// Combined with the normalisation in ignore::non_events (which maps `const T &`
+// → `T &` in the dep_list so no separate pool slot is created), this ensures
+// that a guard taking `const State &` sees the same live object that actions
+// taking `State &` mutate.  Without this overload the generic get_arg below
+// would do aux::get<const State &>(deps) which static_cast-fails or (with
+// BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS) hits the primary-template
+// pool_type_impl whose reference member dangles after construction. (#530)
+template <class T, class TEvent, class Tsm, class TDeps,
+          __BOOST_SML_REQUIRES(!aux::is_same<aux::remove_const_t<aux::remove_reference_t<back::get_event_t<TEvent>>>,
+                                             T>::value)>
+constexpr const T &get_arg(const aux::type_wrapper<const T &> &, const TEvent &, Tsm &, TDeps &deps) {
+  return aux::get<T &>(deps);
+}
 // 6-parameter overloads: look in sub_sms for submachine state types (issue #659)
 // Excluded: the current SM's own type (Tsm::sm_t), which belongs in deps
 template <class T, class TEvent, class Tsm, class TDeps, class TSubs,
@@ -2779,10 +2794,18 @@ template <class E, class... Ts>
 struct ignore<E, aux::type_list<Ts...>> {
   template <class T>
   struct non_events {
+    // Normalise const lvalue refs: `const U &` → `U &`.
+    // This ensures that a guard taking `const State &` and an action taking
+    // `State &` share the same pool slot, so mutations through the mutable ref
+    // are visible through the const ref.  Without normalisation a separate
+    // pool_type<const State &> entry would be created, carrying a stale copy
+    // of the original default-constructed State value. (#530)
+    using stripped_ = aux::remove_const_t<aux::remove_reference_t<T>>;
+    using norm_ = aux::conditional_t<aux::is_same<T, const stripped_ &>::value, stripped_ &, T>;
     using type =
         aux::conditional_t<aux::is_same<back::get_event_t<E>, aux::remove_const_t<aux::remove_reference_t<T>>>::value ||
                                aux::is_same<T, action_base>::value,
-                           aux::type_list<>, aux::type_list<T>>;
+                           aux::type_list<>, aux::type_list<norm_>>;
   };
   using type = aux::join_t<typename non_events<Ts>::type...>;
 };

--- a/test/ft/dependencies.cpp
+++ b/test/ft/dependencies.cpp
@@ -523,3 +523,44 @@ test final_sm_class_compiles = [] {
   sm.process_event(e2{});
   expect(sm.is(sml::X));
 };
+
+// Issue #530: a guard taking `const State &` received a default-constructed copy
+// instead of the live state modified by earlier actions.  Root cause: two separate
+// pool slots were created for `State &` (mutable actions) and `const State &`
+// (const guards), so mutations through the mutable slot were invisible to the const
+// slot.
+// Fix: normalise `const T &` → `T &` in ignore::non_events (single pool slot) and
+// add a get_arg overload that strips const at lookup time so both see the same object.
+#if defined(BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS)
+struct State530 {
+  int id{};
+};
+struct connect530 { int id{}; };
+struct interrupt530 {};
+
+test const_ref_state_dep_sees_live_state = [] {
+  struct c530 {
+    auto operator()() noexcept {
+      using namespace sml;
+      const auto set    = [](const connect530& ev, State530& s) { s.id = ev.id; };
+      // Guard takes const State& — must see the value set by previous `set` action.
+      const auto check  = [](const connect530& ev, const State530& s) {
+        expect(s.id == 42);   // set by the prior `set` action
+        expect(ev.id == 99);
+        return true;
+      };
+      // clang-format off
+      return make_transition_table(
+        *idle + event<connect530>   / set             = sml::state<State530>,
+         sml::state<State530> + event<connect530>[check]           = X
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c530> sm;
+  sm.process_event(connect530{42});   // -> State530, id = 42
+  sm.process_event(connect530{99});   // guard checks const State530& — must see id == 42
+  expect(sm.is(sml::X));
+};
+#endif


### PR DESCRIPTION
## Problem

When a state machine uses `BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS` and an action mutates a state object via `State&` while a subsequent guard reads it via `const State&`, the guard received a **default-constructed copy** instead of the live, mutated value.

**Root cause:** `ignore::non_events` produced two separate dep_list entries — `State&` and `const State&` — which caused two independent pool slots to be allocated and initialised from the same default-constructed object. Mutations via the mutable slot (`State&`) were invisible to the const-ref slot (`const State&`).

### Minimal repro

```cpp
#define BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS
#include <boost/sml.hpp>
struct State { int id{}; };
struct connect { int id{}; };

struct c {
  auto operator()() noexcept {
    using namespace sml;
    const auto set   = [](const connect& ev, State& s) { s.id = ev.id; };
    const auto check = [](const connect& ev, const State& s) {
      return s.id == 42; // FAILED: s.id was 0 (stale copy)
    };
    return make_transition_table(
      *state<struct idle> + event<connect> / set         = state<State>,
       state<State>       + event<connect>[check]        = X
    );
  }
};

sml::sm<c> sm;
sm.process_event(connect{42});  // sets State::id = 42
sm.process_event(connect{99});  // guard should see id==42, but saw 0
```

## Fix (two parts)

**1. `ignore::non_events` normalisation** — map `const U&` → `U&` before inserting into the dep_list, so mutable and const references share a single pool slot:

```cpp
template <class T>
struct non_events {
  using stripped_ = aux::remove_const_t<aux::remove_reference_t<T>>;
  using norm_ = aux::conditional_t<aux::is_same<T, const stripped_&>::value, stripped_&, T>;
  using type =
      aux::conditional_t<..., aux::type_list<>, aux::type_list<norm_>>;
};
```

**2. New `get_arg` overload for `const T&`** — looks up `T&` in the pool (not `const T&`) so both call-sites bind to the same live object:

```cpp
template <class T, class TEvent, class Tsm, class TDeps,
          __BOOST_SML_REQUIRES(!aux::is_same<..., T>::value)>
constexpr const T& get_arg(const aux::type_wrapper<const T&>&,
                            const TEvent&, Tsm&, TDeps& deps) {
  return aux::get<T&>(deps);
}
```

## Test

`test const_ref_state_dep_sees_live_state` added to `test/ft/dependencies.cpp` (compiled under `BOOST_SML_CREATE_DEFAULT_CONSTRUCTIBLE_DEPS`).

Closes #530