### PR TITLE
fix: prevent operator&&/||/! from matching integral_constant-like types (issue #546)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2580,15 +2580,40 @@ class not_ : operator_base {
   T g;
 };
 }  // namespace front
-template <class T, __BOOST_SML_REQUIRES(concepts::callable<bool, T>::value)>
+// Detect integral_constant<bool,V>-like types (std::, aux::, etc.).
+// Such types carry a self-referential 'type' typedef (T::type == T) and a
+// static boolean 'value' member; they are constant-wrappers, not SML guard
+// callables. SML's operator&&/||/! must not grab them or the result is
+// front::and_<...>/or_<...>/not_<...> instead of bool, poisoning any code
+// that combines these types in a TU with 'using namespace boost::sml'. (#546)
+template <class T, class = aux::void_t<>>
+struct is_integral_constant_like : aux::false_type {};
+template <class T>
+struct is_integral_constant_like<T,
+    aux::void_t<decltype(T::value), typename T::type>>
+    : aux::integral_constant<bool,
+        aux::is_same<bool,
+            aux::remove_const_t<decltype(T::value)>>::value &&
+        aux::is_same<T, typename T::type>::value> {};
+template <class T, __BOOST_SML_REQUIRES(
+    concepts::callable<bool, T>::value &&
+    !is_integral_constant_like<T>::value)>
 constexpr auto operator!(const T &t) {
   return front::not_<aux::zero_wrapper<T>>(aux::zero_wrapper<T>{t});
 }
-template <class T1, class T2, __BOOST_SML_REQUIRES(concepts::callable<bool, T1>::value &&concepts::callable<bool, T2>::value)>
+template <class T1, class T2, __BOOST_SML_REQUIRES(
+    concepts::callable<bool, T1>::value &&
+    concepts::callable<bool, T2>::value &&
+    !is_integral_constant_like<T1>::value &&
+    !is_integral_constant_like<T2>::value)>
 constexpr auto operator&&(const T1 &t1, const T2 &t2) {
   return front::and_<aux::zero_wrapper<T1>, aux::zero_wrapper<T2>>(aux::zero_wrapper<T1>{t1}, aux::zero_wrapper<T2>{t2});
 }
-template <class T1, class T2, __BOOST_SML_REQUIRES(concepts::callable<bool, T1>::value &&concepts::callable<bool, T2>::value)>
+template <class T1, class T2, __BOOST_SML_REQUIRES(
+    concepts::callable<bool, T1>::value &&
+    concepts::callable<bool, T2>::value &&
+    !is_integral_constant_like<T1>::value &&
+    !is_integral_constant_like<T2>::value)>
 constexpr auto operator||(const T1 &t1, const T2 &t2) {
   return front::or_<aux::zero_wrapper<T1>, aux::zero_wrapper<T2>>(aux::zero_wrapper<T1>{t1}, aux::zero_wrapper<T2>{t2});
 }

--- a/test/ft/guards.cpp
+++ b/test/ft/guards.cpp
@@ -52,3 +52,47 @@ test guards_logic_should_short_circuit = [] {
   expect(1 == static_cast<const c&>(sm).guard_true_calls);
   expect(sm.is(state2));
 };
+
+// Issue #546: SML's operator&& / operator|| / operator! must not be selected
+// for std::integral_constant<bool,V> (a.k.a. std::true_type / std::false_type)
+// when 'using namespace boost::sml;' is in scope.  Before the fix, combining
+// two std::true_type values with && returned front::and_<...> (an SML guard
+// combinator) instead of bool, which breaks any code that expects the standard
+// && semantics (e.g. Google Mock type-trait machinery on GCC 11+).
+//
+// These two types mimic std::integral_constant<bool,V>:
+//   T::type == T  and  bool T::value  => is_integral_constant_like<T> = true
+//   operator()()                      => callable (like std::integral_constant)
+//   operator bool()                   => built-in &&/||/! work via conversion
+// (File-scope to avoid C++ restriction on static members in local classes.)
+struct ic546_true {
+  using type = ic546_true;
+  static constexpr bool value = true;
+  constexpr bool operator()() const noexcept { return value; }
+  constexpr operator bool() const noexcept { return value; }
+};
+struct ic546_false {
+  using type = ic546_false;
+  static constexpr bool value = false;
+  constexpr bool operator()() const noexcept { return value; }
+  constexpr operator bool() const noexcept { return value; }
+};
+test integral_constant_and_or_not_not_grabbed_by_sml_operators = [] {
+  using namespace sml;  // NOLINT(build/namespaces)
+
+  const ic546_true t{};
+  const ic546_false f{};
+
+  auto r_and = t && t;  // must be bool (built-in &&), not front::and_<...>
+  auto r_or  = f || t;  // must be bool (built-in ||), not front::or_<...>
+  auto r_not = !t;      // must be bool (built-in !),  not front::not_<...>
+
+  // Each decltype must be bool, not an SML combinator type (#546).
+  static_assert(aux::is_same<decltype(r_and), bool>::value, "&&");
+  static_assert(aux::is_same<decltype(r_or),  bool>::value, "||");
+  static_assert(aux::is_same<decltype(r_not), bool>::value, "!");
+
+  expect(r_and == true);
+  expect(r_or  == true);
+  expect(r_not == false);
+};


### PR DESCRIPTION
## Problem

When `using namespace boost::sml;` is in scope, SML's `operator&&`, `operator||`, and `operator!` could be selected for expressions involving `std::true_type` / `std::false_type` (or any `std::integral_constant<bool,V>`), producing an SML guard-combinator type instead of `bool`.

**Root cause:** `std::integral_constant` gained `constexpr bool operator()() const noexcept` in C++14. This makes `concepts::callable<bool, std::true_type>` evaluate to `true`, so SML's overloads become candidates. The result `front::and_<...>` is not convertible to `bool`, which breaks downstream code — most notably Google Mock's type-trait machinery on GCC 11+ where constraint checking is more aggressive.

### Minimal repro

```cpp
#include <boost/sml.hpp>
#include <type_traits>

void example() {
    using namespace boost::sml;       // brings operator&& into scope

    std::true_type t1, t2;
    bool b = t1 && t2;               // ERROR before fix:
    // cannot convert 'front::and_<zero_wrapper<std::true_type>, ...>' to 'bool'
}
```

## Fix

Add `aux::is_integral_constant_like<T>` — a trait that detects types matching the `integral_constant` pattern: a self-referential `type` member typedef (`T::type == T`) combined with a static `bool value` member. Apply it as a negative constraint on the three overloads:

```cpp
// In namespace aux:
template <class T, class = void>
struct is_integral_constant_like : false_type {};
template <class T>
struct is_integral_constant_like<T, void_t<decltype(T::value), typename T::type>>
    : integral_constant<bool, is_same<bool, remove_const_t<decltype(T::value)>>::value &&
                               is_same<T, typename T::type>::value> {};

// On the operators:
template <class T, __BOOST_SML_REQUIRES(concepts::callable<bool, T>::value &&
                                         !aux::is_integral_constant_like<T>::value)>
constexpr auto operator!(const T &t) { ... }

template <class T1, class T2, __BOOST_SML_REQUIRES(concepts::callable<bool, T1>::value &&
                                                    concepts::callable<bool, T2>::value &&
                                                    !aux::is_integral_constant_like<T1>::value &&
                                                    !aux::is_integral_constant_like<T2>::value)>
constexpr auto operator&&(const T1 &t1, const T2 &t2) { ... }
// (same for operator||)
```

The trait detects any namespace's `integral_constant`-like type (not just `std::` or `aux::`), so it's robust to third-party constant-wrapper types as well.

## Test

`test integral_constant_and_or_not_not_grabbed_by_sml_operators` added to `test/ft/guards.cpp`. With `using namespace sml;` in scope it checks — via `static_assert` and runtime `expect` — that `std::true_type && std::true_type`, `std::false_type || std::true_type`, and `!std::true_type` all produce plain `bool`.

Closes #546