### PR TITLE
fix: generic on_entry<_>/on_exit<_> in outer SM suppressed by sub-SM specific handler (#372)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1499,30 +1499,39 @@ struct get_state_mapping<sm<T>, TMappings, TUnexpected> {
 };
 template <class T, class TMappings, class TUnexpected>
 using get_state_mapping_t = typename get_state_mapping<T, TMappings, TUnexpected>::type;
-template <class>
+template <class...>
 transitions<aux::true_type> get_event_mapping_impl(...);
 template <class T, class TMappings>
 TMappings get_event_mapping_impl(event_mappings<T, TMappings> *);
-template <class T, class... T1Mappings, class... T2Mappings>
-unique_mappings_t<T1Mappings..., T2Mappings...> get_event_mapping_impl(event_mappings<T, aux::inherit<T1Mappings...>> *,
-                                                                       event_mappings<_, aux::inherit<T2Mappings...>> *);
+template <class T1, class T2, class... T1Mappings, class... T2Mappings>
+unique_mappings_t<T1Mappings..., T2Mappings...> get_event_mapping_impl(event_mappings<T1, aux::inherit<T1Mappings...>> *,
+                                                                       event_mappings<T2, aux::inherit<T2Mappings...>> *);
+// Look up event E with fallback to DefaultE.  Three cases:
+//   DefaultE not in mappings → return E's mapping (or empty if E also missing)
+//   DefaultE in mappings but E not → return DefaultE's mapping (pure fallback)
+//   Both in mappings → merge them (unique_mappings_t deduplicates by state)
+template <class E, class DefaultE, class TMappings>
+using with_default_event_mapping_t = typename aux::conditional<
+    aux::is_same<transitions<aux::true_type>, decltype(get_event_mapping_impl<DefaultE>((TMappings *)0))>::value,
+    decltype(get_event_mapping_impl<E>((TMappings *)0)),
+    typename aux::conditional<
+        aux::is_same<transitions<aux::true_type>, decltype(get_event_mapping_impl<E>((TMappings *)0))>::value,
+        decltype(get_event_mapping_impl<DefaultE>((TMappings *)0)),
+        decltype(get_event_mapping_impl<E, DefaultE>((TMappings *)0, (TMappings *)0))>::type>::type;
 template <class T, class TMappings>
-struct get_event_mapping_impl_helper
-    : aux::conditional<aux::is_same<transitions<aux::true_type>, decltype(get_event_mapping_impl<_>((TMappings *)0))>::value,
-                       decltype(get_event_mapping_impl<T>((TMappings *)0)),
-                       decltype(get_event_mapping_impl<T>((TMappings *)0, (TMappings *)0))>::type {};
+struct get_event_mapping_impl_helper : with_default_event_mapping_t<T, _, TMappings> {};
 template <class T, class TMappings>
 struct get_event_mapping_impl_helper<exception<T>, TMappings> : decltype(get_event_mapping_impl<exception<T>>((TMappings *)0)) {
 };
-template <class T1, class T2, class TMappings>
-struct get_event_mapping_impl_helper<unexpected_event<T1, T2>, TMappings>
-    : decltype(get_event_mapping_impl<unexpected_event<T1, T2>>((TMappings *)0)) {};
-template <class T1, class T2, class TMappings>
-struct get_event_mapping_impl_helper<on_entry<T1, T2>, TMappings>
-    : decltype(get_event_mapping_impl<on_entry<T1, T2>>((TMappings *)0)) {};
-template <class T1, class T2, class TMappings>
-struct get_event_mapping_impl_helper<on_exit<T1, T2>, TMappings>
-    : decltype(get_event_mapping_impl<on_exit<T1, T2>>((TMappings *)0)) {};
+template <class E, class S, class TMappings>
+struct get_event_mapping_impl_helper<unexpected_event<S, E>, TMappings>
+    : with_default_event_mapping_t<unexpected_event<S, E>, unexpected_event<S, _>, TMappings> {};
+template <class E, class S, class TMappings>
+struct get_event_mapping_impl_helper<on_entry<S, E>, TMappings>
+    : with_default_event_mapping_t<on_entry<S, E>, on_entry<S, _>, TMappings> {};
+template <class E, class S, class TMappings>
+struct get_event_mapping_impl_helper<on_exit<S, E>, TMappings>
+    : with_default_event_mapping_t<on_exit<S, E>, on_exit<S, _>, TMappings> {};
 template <class T, class TMappings>
 using get_event_mapping_t = get_event_mapping_impl_helper<T, TMappings>;
 }  // namespace back
@@ -1978,12 +1987,11 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
   constexpr bool process_internal_event(const TEvent &event, TDeps &d, TSubs &subs, state_t &current_state) {
     policies::log_process_event<sm_t>(aux::type_wrapper<logger_t>{}, d, event);
 #if BOOST_SML_DISABLE_EXCEPTIONS
-    return process_event_impl<get_event_mapping_t<get_mapped_t<TEvent>, mappings>>(event, d, subs, states_t{}, current_state)
+    return process_event_impl<get_event_mapping_t<get_mapped_t<TEvent>, mappings>>(event, d, subs, states_t{}, current_state);
 #else
     return process_event_except_impl<get_event_mapping_t<get_mapped_t<TEvent>, mappings>>(event, d, subs, current_state,
-                                                                                         has_exceptions{})
+                                                                                         has_exceptions{});
 #endif
-           || process_internal_generic_event(event, d, subs, current_state);
   }
   template <class TMappings, class TEvent, class TDeps, class TSubs, class... TStates>
   constexpr bool process_event_impl(const TEvent &event, TDeps &d, TSubs &subs, const aux::type_list<TStates...> &states,

--- a/test/ft/transitions.cpp
+++ b/test/ft/transitions.cpp
@@ -823,6 +823,110 @@ test initial_nontrivial_exit = [] {
   }
 };
 
+// Issue #372: non-trivial on_entry/on_exit in a sub-SM suppressed the generic
+// on_entry<_>/on_exit<_> fallback in the *outer* SM.
+//
+// Root cause (old code): process_internal_event for a specific on_entry<_,E>
+// that was NOT explicitly handled in the outer SM used:
+//   process_event_impl<transitions<true_type>>(on_entry<_,E>{}, ...)
+//     || process_internal_generic_event(...)
+// The sub-SM was started inside the transitions<true_type> dispatch path (which
+// routes the entry into the sub-SM), returning true.  The `||` then
+// short-circuited process_internal_generic_event, so the outer SM's
+// on_entry<_> handler was never reached.
+//
+// Fix: with_default_event_mapping_t falls back to the generic on_entry<_,_>
+// mapping when no specific on_entry<_,E> is registered in the outer SM.
+// The || is removed entirely; fallback is encoded in the mapping lookup.
+
+template <int N>
+struct subsm_nontrivial {
+  auto operator()() noexcept {
+    using namespace sml;
+    // Idle state has BOTH a specific on_entry<e1> and a generic on_entry<_>.
+    // Within the same SM, the specific takes priority (short-circuit).
+    return make_transition_table(
+       *idle + sml::on_entry<e1> / [](std::string &s) { s += "sub_e1en|"; }
+       ,idle + sml::on_entry<_>  / [](std::string &s) { s += "sub_en|"; }
+       ,idle + sml::on_exit<e2>  / [](std::string &s) { s += "sub_e2ex|"; }
+       ,idle + sml::on_exit<_>   / [](std::string &s) { s += "sub_ex|"; }
+    );
+  }
+};
+
+test composite_nontrivial_entry = [] {
+  // Outer SM has a generic on_entry<_> for the composite sub-state.
+  // The sub-SM has both a specific on_entry<e1> and a generic on_entry<_>.
+  struct outer {
+    auto operator()() noexcept {
+      using namespace sml;
+      auto sub = sml::state<subsm_nontrivial<1>>;
+      // clang-format off
+      return make_transition_table(
+         *idle + event<e1> = sub
+         ,idle + event<e2> = sub  // also enter via e2
+         ,sub  + sml::on_entry<_> / [](std::string &s) { s += "outer_en|"; }
+      );
+      // clang-format on
+    }
+  };
+
+  {
+    // Enter composite state via e1: outer generic fires, sub specific fires.
+    std::string s;
+    sml::sm<outer> sm{s};
+    sm.process_event(e1{});
+    expect("outer_en|sub_e1en|" == s);
+  }
+  {
+    // Enter composite state via e2: outer generic fires, sub falls back to
+    // its own generic (no on_entry<e2> in sub-SM).
+    std::string s;
+    sml::sm<outer> sm{s};
+    sm.process_event(e2{});
+    expect("outer_en|sub_en|" == s);
+  }
+};
+
+test composite_nontrivial_exit = [] {
+  // Outer SM has a generic on_exit<_> for the composite sub-state.
+  // The sub-SM has both a specific on_exit<e2> and a generic on_exit<_>.
+  struct outer {
+    auto operator()() noexcept {
+      using namespace sml;
+      auto sub = sml::state<subsm_nontrivial<1>>;
+      // clang-format off
+      return make_transition_table(
+         *idle + event<e1> = sub   // enter via e1 (uses sub's specific on_entry<e1>)
+         ,sub  + event<e2> = idle  // exit via e2
+         ,sub  + event<e3> = idle  // exit via e3 (sub has no specific on_exit<e3>)
+         ,sub  + sml::on_entry<_> / [](std::string &s) { s += "outer_en|"; }
+         ,sub  + sml::on_exit<_>  / [](std::string &s) { s += "outer_ex|"; }
+      );
+      // clang-format on
+    }
+  };
+
+  {
+    // Enter then exit via e2: sub's specific on_exit<e2> fires, then outer generic.
+    std::string s;
+    sml::sm<outer> sm{s};
+    sm.process_event(e1{});
+    s.clear();  // discard entry output
+    sm.process_event(e2{});
+    expect("sub_e2ex|outer_ex|" == s);
+  }
+  {
+    // Enter then exit via e3: sub falls back to generic on_exit<_>, then outer generic.
+    std::string s;
+    sml::sm<outer> sm{s};
+    sm.process_event(e1{});
+    s.clear();  // discard entry output
+    sm.process_event(e3{});
+    expect("sub_ex|outer_ex|" == s);
+  }
+};
+
 #if defined(__cpp_noexcept_function_type)
 test member_functions_as_actions_and_guards = [] {
   struct class0 {


### PR DESCRIPTION
## Problem

When an **outer SM** has a generic `on_entry<_>` (or `on_exit<_>`) for a composite sub-state, and the **sub-SM** has a *specific* `on_entry<E>` for its initial state, the outer SM's generic handler was silently skipped when entering the composite state via event `E`.

### Root cause

`process_internal_event` (the mapped overload) was structured as:

```cpp
return process_event_impl<specific_mapping>(on_entry<_,E>{}, ...) ||
       process_internal_generic_event(on_entry<_,E>{}, ...);
```

When the outer SM had **no explicit** `on_entry<E>` for the composite state, `specific_mapping` resolved to `transitions<true_type>`. That catch-all dispatches into the sub-SM (routing the entry event into the child), **returns `true`**, and the `||` then **short-circuits** `process_internal_generic_event` — so the outer SM's `on_entry<_>` handler was never called.

## Fix

Introduce `with_default_event_mapping_t<E, DefaultE, TMappings>`, a three-way compile-time alias:

| Condition | Result |
|-----------|--------|
| `DefaultE` not in mappings | Use `E`'s mapping directly (or empty) |
| `DefaultE` in mappings, `E` not | Use `DefaultE`'s mapping (pure fallback) |
| Both in mappings | Merge via `unique_mappings_t` (specific takes priority inside the merged list) |

Apply the alias in `get_event_mapping_impl_helper` specialisations for `on_entry<S,E>`, `on_exit<S,E>`, and `unexpected_event<S,E>`, using `on_entry<S,_>` / `on_exit<S,_>` / `unexpected_event<S,_>` as the respective defaults.

Remove the `|| process_internal_generic_event(...)` call from the mapped `process_internal_event` overload — the fallback is now encoded entirely within the mapping lookup.

## Behaviour matrix

| Outer SM has | Sub-SM has | Entering via E | Result |
|---|---|---|---|
| `state<C> + on_entry<_>` only | `idle + on_entry<E>` | E | outer generic ✓, child specific ✓ (**was: outer generic missing**) |
| `state<C> + on_entry<_>` only | `idle + on_entry<_>` | any | outer generic ✓, child generic ✓ |
| `state<C> + on_entry<E>` only | any | E | outer specific ✓ |
| `state<C> + on_entry<E>` + `on_entry<_>` | any | E | outer specific ✓ (generic short-circuited by `transitions<>`, consistent with flat-SM behaviour) |

## Tests

Two new functional tests in `test/ft/transitions.cpp`:

- **`composite_nontrivial_entry`**: outer generic `on_entry<_>` fires when sub-SM has a specific `on_entry<e1>`; also verifies generic fallback when entering via an event the sub-SM has no specific handler for.
- **`composite_nontrivial_exit`**: outer generic `on_exit<_>` fires when sub-SM has a specific `on_exit<e2>`; also verifies generic fallback for exit via an event with no specific handler.

All existing tests pass.