### PR TITLE
fix: operator[]/operator/ SFINAE in trailing return type for MSVC C++20 (issue #515)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2725,12 +2725,14 @@ template <class, class>
 struct transition_ea;
 template <class TEvent>
 struct event {
-  template <class T, BOOST_SML_DETAIL_REQUIRES(concepts::callable<bool, T>::value)>
-  constexpr auto operator[](const T &t) const {
+  template <class T>
+  constexpr auto operator[](const T &t) const
+      -> aux::enable_if_t<concepts::callable<bool, T>::value, transition_eg<event, aux::zero_wrapper<T>>> {
     return transition_eg<event, aux::zero_wrapper<T>>{*this, aux::zero_wrapper<T>{t}};
   }
-  template <class T, BOOST_SML_DETAIL_REQUIRES(concepts::callable<void, T>::value)>
-  constexpr auto operator/(const T &t) const {
+  template <class T>
+  constexpr auto operator/(const T &t) const
+      -> aux::enable_if_t<concepts::callable<void, T>::value, transition_ea<event, aux::zero_wrapper<T>>> {
     return transition_ea<event, aux::zero_wrapper<T>>{*this, aux::zero_wrapper<T>{t}};
   }
   constexpr auto operator()() const { return TEvent{}; }
@@ -2759,12 +2761,14 @@ struct state_impl {
   constexpr auto operator+(const T &t) const {
     return transition<TState, T>{static_cast<const TState &>(*this), t};
   }
-  template <class T, BOOST_SML_DETAIL_REQUIRES(concepts::callable<bool, T>::value)>
-  constexpr auto operator[](const T &t) const {
+  template <class T>
+  constexpr auto operator[](const T &t) const
+      -> aux::enable_if_t<concepts::callable<bool, T>::value, transition_sg<TState, aux::zero_wrapper<T>>> {
     return transition_sg<TState, aux::zero_wrapper<T>>{static_cast<const TState &>(*this), aux::zero_wrapper<T>{t}};
   }
-  template <class T, BOOST_SML_DETAIL_REQUIRES(concepts::callable<void, T>::value)>
-  constexpr auto operator/(const T &t) const {
+  template <class T>
+  constexpr auto operator/(const T &t) const
+      -> aux::enable_if_t<concepts::callable<void, T>::value, transition_sa<TState, aux::zero_wrapper<T>>> {
     return transition_sa<TState, aux::zero_wrapper<T>>{static_cast<const TState &>(*this), aux::zero_wrapper<T>{t}};
   }
 };

--- a/test/ft/guards.cpp
+++ b/test/ft/guards.cpp
@@ -96,3 +96,28 @@ test integral_constant_and_or_not_not_grabbed_by_sml_operators = [] {
   expect(r_or  == true);
   expect(r_not == false);
 };
+
+// Issue #515: event<e>[!guard] and *state[!guard] must compile in C++20 mode
+// (MSVC C++20 failed to deduce T in operator[] when the argument type is
+// front::not_<...> and the SFINAE was expressed as a default template parameter.
+// Fix: move the constraint to the trailing return type.)
+test negated_guard_compiles_on_event_and_state = [] {
+  struct c {
+    auto operator()() {
+      using namespace sml;
+      auto guard_true = [] { return true; };
+
+      // clang-format off
+      return make_transition_table(
+        *state1 + event<event1> [ !guard_true ] = state2,   // event<e>[!guard]
+         state2                 [ !guard_true ] = state3    // *state[!guard]
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c> sm{};
+  // !guard_true always evaluates to false, so neither transition fires.
+  sm.process_event(event1{});
+  expect(sm.is(state1));
+};


### PR DESCRIPTION
## Problem

On MSVC C++20, writing `event<e>[!guard]` or `*state[!guard]` fails to compile with a template argument deduction error. The same pattern works on GCC, Clang, and MSVC C++17.

Root cause: `front::event::operator[]` and `front::state_impl::operator[]` (and the corresponding `operator/` overloads) express their SFINAE constraint as a **default template parameter**:

```cpp
template <class T, typename enable_if<callable<bool, T>::value, int>::type = 0>
constexpr auto operator[](const T &t) const { ... }
```

MSVC C++20 has a known issue where this form of SFINAE can fail to deduce `T` when the argument is a nested dependent type (here: `front::not_<zero_wrapper<Guard>>` produced by `!guard`). Specifically, MSVC's C++20 subscript-operator lookup interacts poorly with default-parameter SFINAE, causing it to reject the overload before deduction completes.

## Fix

Move the `enable_if` constraint to the **trailing return type**, which is the standard and MSVC-compatible form of expression-SFINAE:

```cpp
template <class T>
constexpr auto operator[](const T &t) const
    -> enable_if_t<callable<bool, T>::value, transition_eg<event, zero_wrapper<T>>> { ... }
```

This form of SFINAE has identical semantics — substitution failure removes the overload from the candidate set — but is evaluated strictly after deduction completes, which works correctly on all compilers.

## Affected overloads

- `front::event::operator[]` — `event<e>[guard]` / `event<e>[!guard]`
- `front::event::operator/` — `event<e>/action` (same MSVC risk, fixed for consistency)
- `front::state_impl::operator[]` — `*state[guard]` / `*state[!guard]`
- `front::state_impl::operator/` — `*state/action` (same MSVC risk, fixed for consistency)

## Test

Added `negated_guard_compiles_on_event_and_state` in `test/ft/guards.cpp` that exercises:
- `*state1 + event<event1>[!guard]` (the primary reported failure)
- `state2[!guard]` (the state-subscript form)

Both patterns were already rejected by MSVC C++20 before this fix.

## Compatibility

All existing GCC 14 and Clang tests pass unchanged (C++17 and C++20). The trailing-return-type form is valid C++14 and up.