### PR TITLE
fix: back::process<E> from sub-SM now routes to root SM queue (issue #400)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2375,9 +2375,19 @@ template <class... TEvents, class TEvent, class Tsm, class TDeps>
 constexpr decltype(auto) get_arg(const aux::type_wrapper<back::defer<TEvents...>> &, const TEvent, Tsm &sm, TDeps &) {
   return back::defer<TEvents...>{sm.defer_};
 }
+// 4-param fallback: used when no subs pool is available.
 template <class... TEvents, class TEvent, class Tsm, class TDeps>
 constexpr decltype(auto) get_arg(const aux::type_wrapper<back::process<TEvents...>> &, const TEvent, Tsm &sm, TDeps &) {
   return back::process<TEvents...>{sm.process_};
+}
+// 6-param overload (preferred over the variadic fallback): route to the ROOT
+// SM's process queue so that events pushed via back::process<E> from inside a
+// sub-SM are dispatched by the root SM's drain loop and not silently dropped.
+// The root SM is always the first element of the subs pool (see get_root_sm_t).
+// (#400 / #562)
+template <class... TEvents, class TEvent, class Tsm, class TDeps, class TSubs>
+constexpr decltype(auto) get_arg(const aux::type_wrapper<back::process<TEvents...>> &, const TEvent &, Tsm &, TDeps &, TSubs &subs, int) {
+  return back::process<TEvents...>{aux::get<get_root_sm_t<TSubs>>(subs).process_};
 }
 // For const lvalue-ref dep parameters (`const State &`): look up the non-const
 // `State &` pool slot instead of a separate `const State &` slot.

--- a/test/ft/actions_process.cpp
+++ b/test/ft/actions_process.cpp
@@ -515,3 +515,37 @@ test process_queue_std_queue_compiles_and_works = [] {
   expect(2 == c_.processed);
   expect(sm.is(sml::X));
 };
+
+// Issue #400 / #562: back::process<E> from inside a sub-SM action must enqueue
+// the event on the ROOT SM's process queue, not the sub-SM's local queue.
+// Before the fix, the event was pushed to the sub-SM's queue and never drained
+// by the root SM's loop → silently dropped (root SM only saw "").
+// After the fix, the root SM dispatches e2 and fires the outer-level action.
+struct sub_c400 {
+  auto operator()() const noexcept {
+    using namespace sml;
+    auto back_proc = [](back::process<e2> proc) { proc(e2{}); };
+    // clang-format off
+    return make_transition_table(
+      * s1 + event<e1> / back_proc
+    );
+    // clang-format on
+  }
+};
+struct c400 {
+  std::string received;
+  auto operator()() noexcept {
+    using namespace sml;
+    // clang-format off
+    return make_transition_table(
+      * sml::state<sub_c400> + event<e2> / [this] { received += "e2|"; }
+    );
+    // clang-format on
+  }
+};
+test back_process_from_sub_sm_routes_to_root_queue = [] {
+  sml::sm<c400, sml::process_queue<std::queue>> sm{};
+  sm.process_event(e1{});           // sub-SM fires back_proc → enqueues e2 on root queue
+  const c400 &c_ = sm;
+  expect(c_.received == "e2|");     // before fix: "" (e2 silently dropped)
+};


### PR DESCRIPTION
## Problem

When an action inside a sub-SM calls `back::process<E>` to enqueue an event, the event is pushed to the **sub-SM's own `process_` queue** instead of the root SM's. The root SM's drain loop never empties sub-SM queues, so those events are silently dropped.

Minimal reproducer:

```cpp
struct sub {
  auto operator()() const noexcept {
    using namespace sml;
    return make_transition_table(
      * s1 + event<e1> / [](back::process<e2> proc) { proc(e2{}); }
    );
  }
};
struct root {
  std::string received;
  auto operator()() noexcept {
    using namespace sml;
    return make_transition_table(
      * state<sub> + event<e2> / [this] { received += "e2|"; }
    );
  }
};

sml::sm<root, sml::process_queue<std::queue>> sm;
sm.process_event(e1{});
// Before fix: received == ""    (e2 silently dropped)
// After fix:  received == "e2|"
```

Originally reported in #400 and #562 (with a fix sketch by `rhaschke`).

## Root cause

The 4-parameter `get_arg` overload for `back::process<TEvents...>` receives the **current SM** (`Tsm &sm`) and binds `back::process` to `sm.process_`. When executing a sub-SM action, `sm` is the sub-SM — not the root. The 6-param dispatch falls through the variadic `...` fallback which calls the 4-param version, so the wrong queue is used.

Compare with `front::actions::process` (the inline `sml::process(event)` syntax), which has always correctly used:

```cpp
aux::get<get_root_sm_t<TSubs>>(subs).process_.push(event);
```

## Fix

Add a 6-parameter `get_arg` overload for `back::process<TEvents...>` (preferred over the `...` fallback via the `int`/`...` trick) that binds `back::process` to the **root SM's** queue:

```cpp
template <class... TEvents, class TEvent, class Tsm, class TDeps, class TSubs>
constexpr decltype(auto) get_arg(
    const aux::type_wrapper<back::process<TEvents...>> &,
    const TEvent &, Tsm &, TDeps &, TSubs &subs, int) {
  return back::process<TEvents...>{
      aux::get<get_root_sm_t<TSubs>>(subs).process_};
}
```

For non-nested SMs `get_root_sm_t<TSubs>` returns the root itself — no behaviour change for flat state machines.

## Verification

- GCC C++17 and C++20: all tests pass
- MSVC 19.51.36244 (VS 2022 17.x) C++20: 33/33 pass
- MSVC C++17: 30/33 pass (same 3 pre-existing C4458 upstream failures)
