### PR TITLE
ci: add Codacy cppcheck config and project include paths

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,4 @@
+---
+engines:
+  cppcheck:
+    language: c++

--- a/cppcheck-project.xml
+++ b/cppcheck-project.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="1">
+    <!-- Tell cppcheck where to find <boost/sml.hpp> and common/test.hpp -->
+    <includedir>
+        <dir name="include"/>
+        <dir name="test"/>
+    </includedir>
+</project>


### PR DESCRIPTION
## What

Adds two static-analysis configuration files.

**`.codacy.yml`** — declares `language: c++` for Codacy's cppcheck engine so it analyses C++ source files correctly.

**`cppcheck-project.xml`** — provides include-search paths so that local runs of `cppcheck --project=cppcheck-project.xml` can resolve `<boost/sml.hpp>` and `common/test.hpp` without `missingInclude` noise:

```xml
<includedir>
  <dir name="include"/>   <!-- resolves <boost/sml.hpp> -->
  <dir name="test"/>      <!-- resolves common/test.hpp  -->
</includedir>
```

No `<paths>` element — Codacy passes individual files to cppcheck; the project file provides include configuration only.

## Why

Companion to PR #688 (UBSan fix for issue #249), which adds a new test file `test/ft/issue_249_ubsan.cpp`. Without an include path for `<boost/sml.hpp>`, cppcheck would report a `missingIncludeSystem` false positive on that file in local analysis runs.

The per-file inline suppression (`// cppcheck-suppress missingIncludeSystem`) in PR #688 handles Codacy's cloud runner; this project file handles local `cppcheck` invocations.

## Relation

Companion to **PR #688** — can be merged independently in either order.