### PR TITLE
fix: add sml::deps<Ts...> policy for explicit pool deps (issue #437)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1623,6 +1623,9 @@ template <class T>
 struct logger : aux::pair<logger_policy__, logger<T>> {
   using type = T;
 };
+struct explicit_deps_policy__ {};
+template <class... Ts>
+struct explicit_deps : aux::pair<explicit_deps_policy__, explicit_deps<Ts...>> {};
 template <class>
 struct get_state_name;
 template <class T>
@@ -1763,6 +1766,8 @@ struct sm_policy {
   using logger_policy = decltype(get_policy<no_policy, policies::logger_policy__>((aux::inherit<TPolicies...> *)0));
   using testing_policy = decltype(get_policy<no_policy, policies::testing_policy__>((aux::inherit<TPolicies...> *)0));
   using dont_instantiate_statemachine_class_policy = decltype(get_policy<no_policy, policies::dont_instantiate_statemachine_class_policy__>((aux::inherit<TPolicies...> *)0));
+  using explicit_deps_policy =
+      decltype(get_policy<no_policy, policies::explicit_deps_policy__>((aux::inherit<TPolicies...> *)0));
   using default_dispatch_policy = policies::switch_stm;
   using dispatch_policy =
       decltype(get_policy<default_dispatch_policy, policies::dispatch_policy__>((aux::inherit<TPolicies...> *)0));
@@ -2179,6 +2184,14 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
   typename defer_t::const_iterator defer_it_{};
   typename defer_t::const_iterator defer_end_{};
 };
+template <class>
+struct get_explicit_deps {
+  using type = aux::type_list<>;
+};
+template <class... Ts>
+struct get_explicit_deps<policies::explicit_deps<Ts...>> {
+  using type = aux::type_list<aux::remove_const_t<aux::remove_reference_t<Ts>> &...>;
+};
 template <class Tsm>
 class sm {
   using sm_t = typename Tsm::sm;
@@ -2206,9 +2219,10 @@ class sm {
       aux::apply_t<aux::pool,
                    typename convert_to_sm<Tsm, aux::apply_t<aux::unique_t, aux::apply_t<get_sub_sms, states>>>::type>;
   using dep_list = aux::apply_t<merge_deps, transitions_t>;
+  using explicit_dep_list = typename get_explicit_deps<typename Tsm::explicit_deps_policy>::type;
   using deps_t =
       aux::apply_t<aux::pool,
-                   aux::apply_t<aux::unique_t, aux::join_t<dep_list, sm_all_t, logger_dep_t, aux::apply_t<merge_deps, sub_sms_t>>>>;
+                   aux::apply_t<aux::unique_t, aux::join_t<explicit_dep_list, dep_list, sm_all_t, logger_dep_t, aux::apply_t<merge_deps, sub_sms_t>>>>;
   struct events_ids : aux::apply_t<aux::inherit, events> {};
 
  public:
@@ -2672,6 +2686,8 @@ using defer_queue = back::policies::defer_queue<T>;
 template <template <class...> class T>
 using process_queue = back::policies::process_queue<T>;
 using dont_instantiate_statemachine_class = back::policies::dont_instantiate_statemachine_class;
+template <class... Ts>
+using deps = back::policies::explicit_deps<Ts...>;
 #if defined(_MSC_VER) && !defined(__clang__)
 template <class T, class... TPolicies, class T__ = aux::remove_reference_t<decltype(aux::declval<T>())>>
 using sm = back::sm<back::sm_policy<T__, TPolicies...>>;


### PR DESCRIPTION
## Problem

When all actions and guards use generic 4-arg lambdas to access deps manually:

```cpp
auto action = [](auto /*e*/, auto& /*sm*/, auto& deps, auto& /*states*/) {
    sml::aux::get<MyDep&>(deps).value = 99;
};
```

…`MyDep` never appears in any explicitly-typed parameter list, so `dep_list` (computed via `get_deps_t` → `args_t`) is empty. The pool `deps_t` never includes `MyDep`, and the `static_cast` from the user-provided pool to `pool_type<MyDep&>` fails to compile:

```
error: static_cast from 'aux::pool<>' to 'aux::pool_type<MyDep&>' is not valid
```

Closes #437.

## Fix

Introduce `sml::deps<Ts...>` as a new SM policy that widens the deps pool to include explicitly named types:

```cpp
MyDep dep;
sml::sm<MyTable, sml::deps<MyDep>> sm{dep};
```

### Implementation

1. **`back::policies::explicit_deps<Ts...>`** — new policy struct, follows same `aux::pair<Tag__, Self>` pattern as `logger`, `thread_safe`, etc.
2. **`sm_policy::explicit_deps_policy`** — picked up via the existing `get_policy` mechanism.
3. **`get_explicit_deps<P>` helper** — converts `explicit_deps<Ts...>` → `type_list<Ts&...>` (with same `const T&` → `T&` normalization as `ignore::non_events`); `no_policy` → empty list.
4. **`sm::deps_t`** — joins `explicit_dep_list` before the auto-deduced `dep_list`; `unique_t` deduplicates when both list the same dep.
5. **Public alias** — `template<class... Ts> using deps = back::policies::explicit_deps<Ts...>;`

The design is purely additive: existing SMs without the policy are unchanged.

## Verified

- GCC 14 C++17: 29/29 ft ✅
- GCC 14 C++20: 29/29 ft ✅
- MSVC 19.51 C++20: 34/34 ✅

Companion test PR: #691