### PR TITLE
test: add ft test for sml::deps<Ts...> explicit pool deps (issue #437)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1623,6 +1623,9 @@ template <class T>
 struct logger : aux::pair<logger_policy__, logger<T>> {
   using type = T;
 };
+struct explicit_deps_policy__ {};
+template <class... Ts>
+struct explicit_deps : aux::pair<explicit_deps_policy__, explicit_deps<Ts...>> {};
 template <class>
 struct get_state_name;
 template <class T>
@@ -1763,6 +1766,8 @@ struct sm_policy {
   using logger_policy = decltype(get_policy<no_policy, policies::logger_policy__>((aux::inherit<TPolicies...> *)0));
   using testing_policy = decltype(get_policy<no_policy, policies::testing_policy__>((aux::inherit<TPolicies...> *)0));
   using dont_instantiate_statemachine_class_policy = decltype(get_policy<no_policy, policies::dont_instantiate_statemachine_class_policy__>((aux::inherit<TPolicies...> *)0));
+  using explicit_deps_policy =
+      decltype(get_policy<no_policy, policies::explicit_deps_policy__>((aux::inherit<TPolicies...> *)0));
   using default_dispatch_policy = policies::switch_stm;
   using dispatch_policy =
       decltype(get_policy<default_dispatch_policy, policies::dispatch_policy__>((aux::inherit<TPolicies...> *)0));
@@ -2179,6 +2184,14 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
   typename defer_t::const_iterator defer_it_{};
   typename defer_t::const_iterator defer_end_{};
 };
+template <class>
+struct get_explicit_deps {
+  using type = aux::type_list<>;
+};
+template <class... Ts>
+struct get_explicit_deps<policies::explicit_deps<Ts...>> {
+  using type = aux::type_list<aux::remove_const_t<aux::remove_reference_t<Ts>> &...>;
+};
 template <class Tsm>
 class sm {
   using sm_t = typename Tsm::sm;
@@ -2206,9 +2219,10 @@ class sm {
       aux::apply_t<aux::pool,
                    typename convert_to_sm<Tsm, aux::apply_t<aux::unique_t, aux::apply_t<get_sub_sms, states>>>::type>;
   using dep_list = aux::apply_t<merge_deps, transitions_t>;
+  using explicit_dep_list = typename get_explicit_deps<typename Tsm::explicit_deps_policy>::type;
   using deps_t =
       aux::apply_t<aux::pool,
-                   aux::apply_t<aux::unique_t, aux::join_t<dep_list, sm_all_t, logger_dep_t, aux::apply_t<merge_deps, sub_sms_t>>>>;
+                   aux::apply_t<aux::unique_t, aux::join_t<explicit_dep_list, dep_list, sm_all_t, logger_dep_t, aux::apply_t<merge_deps, sub_sms_t>>>>;
   struct events_ids : aux::apply_t<aux::inherit, events> {};
 
  public:
@@ -2672,6 +2686,8 @@ using defer_queue = back::policies::defer_queue<T>;
 template <template <class...> class T>
 using process_queue = back::policies::process_queue<T>;
 using dont_instantiate_statemachine_class = back::policies::dont_instantiate_statemachine_class;
+template <class... Ts>
+using deps = back::policies::explicit_deps<Ts...>;
 #if defined(_MSC_VER) && !defined(__clang__)
 template <class T, class... TPolicies, class T__ = aux::remove_reference_t<decltype(aux::declval<T>())>>
 using sm = back::sm<back::sm_policy<T__, TPolicies...>>;

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -96,4 +96,9 @@ add_test(test_unexpected_events test_unexpected_events)
 add_executable(test_dont_instantiate_statemachine_class dont_instantiate_statemachine_class.cpp)
 add_test(test_dont_instantiate_statemachine_class test_dont_instantiate_statemachine_class)
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_437_explicit_deps.cpp)
+  add_executable(test_issue_437_explicit_deps issue_437_explicit_deps.cpp)
+  add_test(test_issue_437_explicit_deps test_issue_437_explicit_deps)
+endif()
+
 add_subdirectory(errors)

--- a/test/ft/issue_437_explicit_deps.cpp
+++ b/test/ft/issue_437_explicit_deps.cpp
@@ -1,0 +1,80 @@
+// Issue #437: Dependency silently dropped from pool when only used via generic lambda
+// (i.e. no explicitly-typed action/guard parameter names the dep type).
+//
+// Repro: a dep that is only accessed inside a generic 4-arg lambda via
+//   sml::aux::get<Dep&>(deps)
+// never appears in the auto-deduced dep_list, so the pool<> never contains Dep,
+// and the static_cast from pool<> → pool_type<Dep&> fails at compile time.
+//
+// Fix: allow the user to declare explicit deps via sml::deps<Dep> SM policy so
+// the pool is widened to include those types even when no action/guard signature
+// names them explicitly.
+// cppcheck-suppress missingIncludeSystem
+#include <boost/sml.hpp>
+
+namespace sml = boost::sml;
+
+struct event1 {};
+struct event2 {};
+
+struct MyDep {
+    int value = 42;
+};
+
+// Only generic 4-arg lambdas — MyDep never appears in any signature.
+// Without the fix this fails to compile because MyDep is not in dep_list.
+test generic_lambda_with_explicit_deps = [] {
+    struct table {
+        auto operator()() const {
+            using namespace sml;
+            auto action = [](auto /*e*/, auto& /*sm*/, auto& deps, auto& /*states*/) {
+                aux::get<MyDep&>(deps).value = 99;
+            };
+            auto guard = [](auto /*e*/, auto& /*sm*/, auto& deps, auto& /*states*/) {
+                return aux::get<MyDep&>(deps).value == 99;
+            };
+            return make_transition_table(
+                *"idle"_s + event<event1> / action = "middle"_s,
+                 "middle"_s + event<event2> [guard] = X
+            );
+        }
+    };
+
+    MyDep dep;
+    // sml::deps<MyDep> policy tells the pool to include MyDep even though no
+    // action/guard parameter list names it explicitly.
+    sml::sm<table, sml::deps<MyDep>> sm{dep};
+
+    sm.process_event(event1{});
+    expect(dep.value == 99);  // action ran
+
+    sm.process_event(event2{});
+    expect(sm.is(sml::X));   // guard passed
+};
+
+test generic_lambda_multi_explicit_deps = [] {
+    struct Dep1 { int x = 1; };
+    struct Dep2 { int y = 2; };
+
+    struct table {
+        auto operator()() const {
+            using namespace sml;
+            auto action = [](auto /*e*/, auto& /*sm*/, auto& deps, auto& /*states*/) {
+                aux::get<Dep1&>(deps).x = 10;
+                aux::get<Dep2&>(deps).y = 20;
+            };
+            return make_transition_table(
+                *"s"_s + event<event1> / action = X
+            );
+        }
+    };
+
+    Dep1 d1;
+    Dep2 d2;
+    sml::sm<table, sml::deps<Dep1, Dep2>> sm{d1, d2};
+
+    sm.process_event(event1{});
+    expect(d1.x == 10);
+    expect(d2.y == 20);
+    expect(sm.is(sml::X));
+};


### PR DESCRIPTION
## What

Feature tests for the `sml::deps<Ts...>` SM policy introduced in companion fix PR #690.

**This branch includes the `sml.hpp` implementation from PR #690** so that CI
can build and run the tests independently. If #690 is merged before this PR, this
branch will be rebased to drop the now-redundant `sml.hpp` commit.

## Scenarios covered

**`generic_lambda_with_explicit_deps`** — single dep accessed only via generic 4-arg lambda (`sml::aux::get<Dep&>(deps)`); no action/guard signature ever names the type. Verifies the action mutates the dep and the guard reads the updated value.

**`generic_lambda_multi_explicit_deps`** — two deps declared via `sml::deps<Dep1, Dep2>`, both accessed exclusively through the generic 4-arg form.

## Files changed

- `include/boost/sml.hpp` — `sml::deps<Ts...>` policy (same as PR #690)
- `test/ft/issue_437_explicit_deps.cpp` — new test file
- `test/ft/CMakeLists.txt` — register `test_issue_437_explicit_deps` (guarded with `if(EXISTS ...)`)

## Cross-references

- Implementation PR: #690
- Fixes: #437