### PR TITLE
fix: replace if constexpr with C++14 tag-dispatch in update_composite_states (PR #684 regression)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -3051,6 +3051,15 @@ template<class T>
 constexpr bool is_composite_state_v = is_composite_state<T>::value;
 } // namespace detail
 
+// C++14-compatible tag-dispatch helper for update_composite_states.
+// Forward-declared here so update_composite_states below can call it;
+// definitions follow after update_composite_states (to allow the
+// true_type body to call update_composite_states recursively).
+template <class T, class TSubs>
+constexpr void recurse_composite(TSubs &, aux::false_type);
+template <class T, class TSubs>
+constexpr void recurse_composite(TSubs &subs, aux::true_type);
+
 template <class T, class TSubs, class... Ts>
 constexpr void update_composite_states(TSubs &subs, aux::false_type, Ts &&...) {
   back::sub_sm<T>::get(&subs).initialize(typename T::initial_states_t{});
@@ -3058,11 +3067,20 @@ constexpr void update_composite_states(TSubs &subs, aux::false_type, Ts &&...) {
   aux::for_each(typename T::initial_states_t{},
                 [&](auto state_identity){
                   using state_t = typename decltype(state_identity)::type;
-                  if constexpr (detail::is_composite_state_v<state_t>) {
-                    using sm_impl_t = aux::apply_t<back::sm_impl, state_t>;
-                    update_composite_states<sm_impl_t>(subs, aux::false_type{}, Ts{}...);
-                  }
+                  recurse_composite<state_t>(
+                      subs,
+                      aux::integral_constant<bool, detail::is_composite_state_v<state_t>>{});
                 });
+}
+
+// Definitions after update_composite_states so the true_type body can
+// call update_composite_states<sm_impl_t> which is now fully declared.
+template <class T, class TSubs>
+constexpr void recurse_composite(TSubs &, aux::false_type) {}
+template <class T, class TSubs>
+constexpr void recurse_composite(TSubs &subs, aux::true_type) {
+  using sm_impl_t = aux::apply_t<back::sm_impl, T>;
+  update_composite_states<sm_impl_t>(subs, aux::false_type{});
 }
 template <class SM, class TDeps, class TSubs, class TSrcState, class TDstState>
 constexpr void update_current_state(SM &, TDeps &deps, TSubs &, typename SM::state_t &current_state,


### PR DESCRIPTION
## Problem

PR #684 introduced `update_composite_states` which uses `if constexpr` to
conditionally recurse into nested composite states:

```cpp
if constexpr (detail::is_composite_state_v<state_t>) {
    using sm_impl_t = aux::apply_t<back::sm_impl, state_t>;
    update_composite_states<sm_impl_t>(subs, aux::false_type{}, Ts{}...);
}
```

`if constexpr` is a C++17 feature. This silently breaks C++14 builds:

```
sml.hpp:3061:19: error: 'if constexpr' is incompatible with C++14
```

## Fix

Replace with a forward-declared tag-dispatch pair (`recurse_composite`) that
is fully C++14 compatible:

- Forward declarations of `recurse_composite<T>(TSubs&, aux::false_type)` and
  `recurse_composite<T>(TSubs&, aux::true_type)` appear **before**
  `update_composite_states` so the lambda body can call them.
- Full definitions appear **after** `update_composite_states` so the
  `true_type` overload can call `update_composite_states` (which is then
  fully declared).
- The branch uses `aux::integral_constant<bool, detail::is_composite_state_v<state_t>>{}`
  to select the right overload at compile time — identical semantics to
  `if constexpr`, zero runtime cost.

## Related

- Regression introduced in: #684
- CMake guard for `constexpr.cpp` C++14 issue: #694
- Upstream tracking issue for `constexpr.cpp` in Makefile: #693

## Testing

Verified with `-std=c++14`, `-std=c++17`, and `-std=c++20` via both
`make test` (GCC) and CMake + CTest (GCC 14, Clang 18, MSVC 19.x).

All existing functional tests pass in all three standards.