### PR TITLE
fix(cmake): guard test_constexpr for C++17+; remove duplicate add_test

### DIFF
--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -16,8 +16,11 @@ add_test(test_actions_process_n_defer test_actions_process_n_defer)
 add_executable(test_composite composite.cpp)
 add_test(test_composite test_composite)
 
-add_executable(test_constexpr constexpr.cpp)
-add_test(test_constexpr test_constexpr)
+# constexpr.cpp uses constexpr lambdas and static_assert without message (C++17)
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
+  add_executable(test_constexpr constexpr.cpp)
+  add_test(test_constexpr test_constexpr)
+endif()
 
 add_executable(test_dependencies dependencies.cpp)
 add_test(test_dependencies test_dependencies)
@@ -75,8 +78,6 @@ target_link_libraries(test_policies_thread_safe -lpthread)
 
 add_executable(test_sizeof sizeof.cpp)
 add_test(test_sizeof test_sizeof)
-
-add_test(test_constexpr test_constexpr)
 
 add_executable(test_state_machine state_machine.cpp)
 add_test(test_state_machine test_state_machine)


### PR DESCRIPTION
## Problem

`test/ft/constexpr.cpp` uses two C++17-only features:
- Constexpr lambdas
- `static_assert` without message

`test/ft/CMakeLists.txt` registered the target unconditionally, so a
CMake-based C++14 build would attempt to compile it and fail.

Additionally, the file had a duplicate `add_test(test_constexpr test_constexpr)`
left at line 82 from an earlier refactor, which caused a CMake warning about a
duplicate test name.

## Fix

Wrap `add_executable(test_constexpr)` and `add_test(test_constexpr)` in:
```cmake
if(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
  ...
endif()
```

Remove the duplicate `add_test` entry.

## Related

- Upstream tracking issue: #693

## Testing

- CMake C++14 build: `test_constexpr` target absent, all other 34 tests pass.
- CMake C++17 build: `test_constexpr` present and passes; total 35 tests pass.
- CMake C++20 build: 35 tests pass.

Note: the root `Makefile` still lacks this guard — tracked in #693.