### PR TITLE
fix: include process(E{}) events in events_t so queue can store them (#580)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1272,6 +1272,23 @@ using get_sub_internal_events =
                 typename get_sub_internal_events_impl<typename Ts::dst_state, typename Ts::event>::type...>;
 template <class... Ts>
 using get_events = aux::type_list<typename Ts::event...>;
+// Marker injected into transition deps by the get_deps specialisations for
+// front::actions::process::process_impl (the sml::process() helper) so that
+// events pushed via process(E{}) are added to events_t and the process queue
+// can store them even when E never appears as a transition-row event. (#580)
+template <class T>
+struct process_event_marker {};
+// Extract TEvents... from back::process<TEvents...> dep slots (lambda style:
+// [](back::process<E> p){...}) and from process_event_marker<T> (sml::process()
+// helper style) so that both usage forms add E to events_t. (#580)
+template <class T>
+struct get_process_events_impl : aux::type_list<> {};
+template <class... TEvents>
+struct get_process_events_impl<back::process<TEvents...>> : aux::type_list<TEvents...> {};
+template <class T>
+struct get_process_events_impl<process_event_marker<T>> : aux::type_list<T> {};
+template <class... Ts>
+using get_process_events = aux::join_t<typename get_process_events_impl<Ts>::type...>;
 template <class T>
 struct get_exception : aux::type_list<> {};
 template <class T>
@@ -1894,7 +1911,7 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
   using has_history_states =
       aux::integral_constant<bool, aux::size<initial_states_t>::value != aux::size<history_states_t>::value>;
   using sub_internal_events_t = aux::apply_t<aux::unique_t, aux::apply_t<get_sub_internal_events, transitions_t>>;
-  using events_t = aux::apply_t<aux::unique_t, aux::join_t<sub_internal_events_t, aux::apply_t<get_all_events, transitions_t>>>;
+  using events_t = aux::apply_t<aux::unique_t, aux::join_t<sub_internal_events_t, aux::apply_t<get_all_events, transitions_t>, aux::apply_t<get_process_events, aux::apply_t<merge_deps, transitions_t>>>>;
   using events_ids_t = aux::apply_t<aux::inherit, events_t>;
   using has_unexpected_events = typename aux::is_base_of<unexpected, aux::apply_t<aux::inherit, events_t>>::type;
   using has_entry_exits = typename aux::is_base_of<entry_exit, aux::apply_t<aux::inherit, events_t>>::type;
@@ -2942,6 +2959,17 @@ using get_deps_t = typename get_deps<T, E>::type;
 template <template <class...> class T, class... Ts, class E>
 struct get_deps<T<Ts...>, E, aux::enable_if_t<aux::is_base_of<operator_base, T<Ts...>>::value>> {
   using type = aux::join_t<get_deps_t<Ts, E>...>;
+};
+// Inject back::process_event_marker<TEvent> into deps for sml::process(E{})
+// actions so events pushed via the built-in helper are captured in events_t
+// even when E never appears in a transition-row event slot. (#580)
+template <class TEvent, class E>
+struct get_deps<front::actions::process::process_impl<TEvent>, E> {
+  using type = aux::type_list<back::process_event_marker<TEvent>>;
+};
+template <class TEvent, class E>
+struct get_deps<aux::zero_wrapper<front::actions::process::process_impl<TEvent>>, E> {
+  using type = aux::type_list<back::process_event_marker<TEvent>>;
 };
 struct always {
   using type = always;

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -107,4 +107,9 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_384_544_anon_composite.cpp)
   add_test(test_issue_384_544_anon_composite test_issue_384_544_anon_composite)
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_580_process_events.cpp)
+  add_executable(test_issue_580_process_events issue_580_process_events.cpp)
+  add_test(test_issue_580_process_events test_issue_580_process_events)
+endif()
+
 add_subdirectory(errors)

--- a/test/ft/issue_580_process_events.cpp
+++ b/test/ft/issue_580_process_events.cpp
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2016-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// Issue #580: back::process<E> fails with a template error when event E is not
+// referenced in any transition row (only in the action parameter list).
+//
+#include <boost/sml.hpp>
+#include <queue>
+
+namespace sml = boost::sml;
+
+struct e1 {};
+struct e2 {};
+
+// States at file scope so both SM definition and test share the same type.
+const auto s580_s1 = sml::state<class s580_s1_t>;
+const auto s580_s2 = sml::state<class s580_s2_t>;
+
+// e2 appears in both a transition row and as the process() argument.
+struct sm_580a {
+  auto operator()() noexcept {
+    using namespace sml;
+    // clang-format off
+    return make_transition_table(
+        *s580_s1 + event<e1> / process(e2{}) = s580_s2
+      , s580_s2 + event<e2>                  = X
+    );
+    // clang-format on
+  }
+};
+
+// e2 appears ONLY as a process() argument — never in a transition-row event
+// slot.  Before the fix, this produced a template error because process_t was
+// built from events_t which excluded e2.
+struct sm_580b {
+  auto operator()() noexcept {
+    using namespace sml;
+    // clang-format off
+    return make_transition_table(
+        *s580_s1 + event<e1> / process(e2{}) = s580_s2
+    );
+    // clang-format on
+  }
+};
+
+// Lambda style: [](back::process<e2> p){...} — e2 only in lambda parameter.
+struct sm_580c {
+  auto operator()() noexcept {
+    using namespace sml;
+    // clang-format off
+    return make_transition_table(
+        *s580_s1 + event<e1> /
+            [](sml::back::process<e2> p) { p(e2{}); } = s580_s2
+    );
+    // clang-format on
+  }
+};
+
+test process_event_e2_in_row = [] {
+  sml::sm<sm_580a, sml::process_queue<std::queue>> sm;
+  expect(sm.is(s580_s1));
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test process_event_e2_not_in_row = [] {
+  // e2 only referenced via process(e2{}); should compile and run without error.
+  sml::sm<sm_580b, sml::process_queue<std::queue>> sm;
+  expect(sm.is(s580_s1));
+  sm.process_event(e1{});
+  // e2 is queued but has no transition handler — SM stays in s580_s2.
+  expect(sm.is(s580_s2));
+};
+
+test process_event_lambda_style = [] {
+  // Lambda style back::process<e2>; e2 only in lambda parameter.
+  sml::sm<sm_580c, sml::process_queue<std::queue>> sm;
+  expect(sm.is(s580_s1));
+  sm.process_event(e1{});
+  // e2 is queued but has no transition handler — SM stays in s580_s2.
+  expect(sm.is(s580_s2));
+};

--- a/test/ft/issue_580_process_events.cpp
+++ b/test/ft/issue_580_process_events.cpp
@@ -8,7 +8,9 @@
 // Issue #580: back::process<E> fails with a template error when event E is not
 // referenced in any transition row (only in the action parameter list).
 //
+// cppcheck-suppress missingIncludeSystem
 #include <boost/sml.hpp>
+// cppcheck-suppress missingIncludeSystem
 #include <queue>
 
 namespace sml = boost::sml;


### PR DESCRIPTION
## Problem

When an event `E` is pushed via `sml::process(E{})` (or the lambda form `[](back::process<E> p){...}`) but `E` never appears as a transition-row event, the SM fails to compile with a hard template error:

```
error: no matching function for call to 'get_id<int, E>(queue_event<...>::ids_t*)'
```

Root cause: `events_t` in `sm_impl` is built from `get_all_events` which only scans transition-row event slots. Events referenced only via action parameters are excluded, so `process_t = process_queue_t<queue_event<events_t>>` has no slot for `E`, and pushing `E` fails.

## Fix

Three small additions to `include/boost/sml.hpp`:

1. **`back::process_event_marker<T>`** — an empty, trivially default-constructible tag struct used only for event-set bookkeeping.

2. **Two `get_deps` specialisations** (in the `front` namespace) for `process_impl<TEvent>` and `zero_wrapper<process_impl<TEvent>>` — these return `type_list<back::process_event_marker<TEvent>>` so that `merge_deps` surfaces the pushed event type.

3. **`get_process_events_impl<process_event_marker<T>>`** specialisation — extracted `T` is added to `events_t`, alongside the existing `back::process<TEvents...>` specialisation for the lambda-param style.

The marker type is default-constructible so it contributes an empty base to the deps pool without requiring any user-provided constructor argument. It is never accessed at runtime.

## Test

`test/ft/issue_580_process_events.cpp` covers three cases:
- `e2` present in both `process(e2{})` and a transition row (sanity check)
- `e2` **only** in `process(e2{})` — the broken case before this fix
- `e2` **only** as a lambda `back::process<e2>` parameter

## Verification

| Compiler | Standard | Tests |
|----------|----------|-------|
| GCC 14   | C++14    | 32/32 ✅ |
| GCC 14   | C++17    | 33/33 ✅ |
| GCC 14   | C++20    | 33/33 ✅ |
| MSVC 19.51 | C++20  | 31/31 ✅ |

Closes #580