### PR TITLE
fix(#622): any-state wildcard fires when composable sub-SM terminates

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -869,6 +869,14 @@ template <class R, class T, int N>
 constexpr R get_id(type_id_type<N, T> *) {
   return static_cast<R>(N);
 }
+template <class R, class T, int N>
+constexpr R get_id_safe(type_id_type<N, T> *) {
+  return static_cast<R>(N);
+}
+template <class R, class T>
+constexpr R get_id_safe(...) {
+  return static_cast<R>(-1);
+}
 template <template <class...> class, class T>
 struct is : false_type {};
 template <template <class...> class T, class... Ts>
@@ -1595,8 +1603,11 @@ struct get_state_mapping<sm<T>, TMappings, TUnexpected> {
   struct type : sub_sm_mapping {
     template <class TEvent, class TSm, class TDeps, class TSubs>
     constexpr static bool execute(const TEvent& event, TSm& sm, TDeps& deps, TSubs& subs, typename TSm::state_t& current_state) {
-      return sub_sm_mapping::template execute<TEvent, TSm, TDeps, TSubs>(event, sm, deps, subs, current_state) ||
-             fallback_event_mapping::template execute<TEvent, TSm, TDeps, TSubs>(event, sm, deps, subs, current_state);
+      const auto sub_handled = sub_sm_mapping::template execute<TEvent, TSm, TDeps, TSubs>(event, sm, deps, subs, current_state);
+      if (sub_handled && !sub_sm<sm_impl<T>>::get(&subs).is_terminated()) {
+        return true;
+      }
+      return fallback_event_mapping::template execute<TEvent, TSm, TDeps, TSubs>(event, sm, deps, subs, current_state) || sub_handled;
     }
   };
 };
@@ -2265,15 +2276,15 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
   }
   constexpr bool is_terminated() const { return is_terminated_impl(aux::make_index_sequence<regions>{}); }
   constexpr bool is_terminated_impl(aux::index_sequence<0>) const {
-    return current_state_[0] == aux::get_id<state_t, terminate_state>((states_ids_t *)0);
+    return current_state_[0] == aux::get_id_safe<state_t, terminate_state>((states_ids_t *)0);
   }
   template <int... Ns>
   constexpr bool is_terminated_impl(aux::index_sequence<Ns...>) const {
 #if defined(__cpp_fold_expressions)
-    return ((current_state_[Ns] == aux::get_id<state_t, terminate_state>((states_ids_t *)0)) && ...);
+    return ((current_state_[Ns] == aux::get_id_safe<state_t, terminate_state>((states_ids_t *)0)) && ...);
 #else
     auto result = true;
-    (void)aux::swallow{0, (result &= current_state_[Ns] == aux::get_id<state_t, terminate_state>((states_ids_t *)0))...};
+    (void)aux::swallow{0, (result &= current_state_[Ns] == aux::get_id_safe<state_t, terminate_state>((states_ids_t *)0))...};
     return result;
 #endif
   }

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -127,4 +127,9 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_643_clear_defer_action.cpp)
   add_test(test_issue_643_clear_defer_action test_issue_643_clear_defer_action)
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_622_any_state_nested.cpp)
+  add_executable(test_issue_622_any_state_nested issue_622_any_state_nested.cpp)
+  add_test(test_issue_622_any_state_nested test_issue_622_any_state_nested)
+endif()
+
 add_subdirectory(errors)

--- a/test/ft/issue_622_any_state_nested.cpp
+++ b/test/ft/issue_622_any_state_nested.cpp
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2016-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// Issue #622: `any` wildcard in outer SM is never checked when the outer SM is
+//   in a composable sub-state (struct with public operator()) that itself
+//   handles the triggering event — the sub-SM's dispatch short-circuits the
+//   outer wildcard even after the sub-SM terminates.
+//
+// cppcheck-suppress missingIncludeSystem
+#include <boost/sml.hpp>
+
+namespace sml = boost::sml;
+
+struct e1 {};
+struct e2 {};
+
+struct state_init {};
+struct state_b {};
+struct state_inner {};
+
+// struct → public operator() → composable → treated as sm<sub_a>
+struct sub_a {
+  auto operator()() const noexcept {
+    using namespace sml;
+    return make_transition_table(
+        *state<state_inner> + event<e1> = X  // sub-SM handles e1 and terminates
+    );
+  }
+};
+
+// Outer SM: init -e2-> sub_a; any -e1-> state_b
+struct outer {
+  auto operator()() const noexcept {
+    using namespace sml;
+    const auto any = state<_>;
+    // clang-format off
+    return make_transition_table(
+        *state<state_init> + event<e2> = state<sub_a>
+      , any               + event<e1> = state<state_b>  // wildcard: anywhere → b on e1
+    );
+    // clang-format on
+  }
+};
+
+// After e2: outer SM is in sub_a (sub-SM starts in state_inner).
+// After e1: sub-SM handles e1 (state_inner→X, terminates).
+//           Outer wildcard any+e1→state_b must then fire.
+// Expected: outer SM is in state_b.
+test any_state_fires_after_nested_sub_sm_terminates = [] {
+  sml::sm<outer> sm;
+
+  expect(sm.is(sml::state<state_init>));
+
+  sm.process_event(e2{});
+  expect(sm.is(sml::state<sub_a>));
+  expect(sm.is<decltype(sml::state<sub_a>)>(sml::state<state_inner>));
+
+  sm.process_event(e1{});
+  expect(sm.is(sml::state<state_b>));
+};
+
+// When the outer SM is in a regular (non-composable) state, the wildcard
+// already works correctly.  Verify this baseline is not regressed.
+struct state_leaf {};
+struct outer_leaf_only {
+  auto operator()() const noexcept {
+    using namespace sml;
+    const auto any = state<_>;
+    // clang-format off
+    return make_transition_table(
+        *state<state_init> + event<e2> = state<state_leaf>
+      , any                + event<e1> = state<state_b>
+    );
+    // clang-format on
+  }
+};
+
+test any_state_leaf_baseline = [] {
+  sml::sm<outer_leaf_only> sm;
+
+  sm.process_event(e2{});
+  expect(sm.is(sml::state<state_leaf>));
+
+  sm.process_event(e1{});
+  expect(sm.is(sml::state<state_b>));
+};


### PR DESCRIPTION
## Problem

When the outer SM is in a composable sub-state (a `struct` with public `operator()`, treated as `sm<T>`) and the sub-SM handles an event that terminates all its regions (reaches `X`), the outer wildcard transition (`any + event<E> = state<S>`) was never evaluated.

Root cause: `get_state_mapping<sm<T>>::type::execute()` short-circuits via `||` when `sub_sm_mapping::execute()` returns `true` — so `fallback_event_mapping` (the outer `_` wildcard) is never tried, even after the sub-SM has terminated.

The author of #622 noted that the same SM declared as `class` (private `operator()`, not composable) worked correctly, because non-composable states go through the primary `get_state_mapping` template which always tries both `state_mapping` and `any_state_mapping`.

## Fix

In `get_state_mapping<sm<T>, TMappings, TUnexpected>::type::execute()`:

```cpp
// Before
return sub_sm_mapping::execute(...) || fallback_event_mapping::execute(...);

// After
const auto sub_handled = sub_sm_mapping::execute(...);
if (sub_handled && !sub_sm<sm_impl<T>>::get(&subs).is_terminated()) {
  return true;  // sub-SM handled event and is still running
}
// sub-SM terminated or didn't handle — give outer wildcard a chance
return fallback_event_mapping::execute(...) || sub_handled;
```

**`get_id_safe<R,T>`** is added as a variadic-fallback variant of `get_id` that returns `static_cast<R>(-1)` when `T` is not in the state list. This makes `is_terminated_impl` safe to call on sub-SMs that have no `X`-terminating transitions (previously it would fail to compile for them). The value `-1` can never equal a valid (non-negative) state ID, so `is_terminated()` correctly returns `false` for such SMs.

## Test

`test/ft/issue_622_any_state_nested.cpp`:
- **`any_state_fires_after_nested_sub_sm_terminates`**: outer SM in composable `sub_a`; `e1` terminates the sub-SM and the outer wildcard `any + e1 = state_b` must fire → outer SM in `state_b`.
- **`any_state_leaf_baseline`**: wildcard for non-composable (leaf) states works as before.

## Verification

| Toolchain | Standard | Result |
|-----------|----------|--------|
| GCC 14 (Docker) | C++14 | 33/33 (pre-existing C++14 `static_assert` failure unrelated to this PR, tracked by #698) |
| GCC 14 (Docker) | C++17 | 33/33 ✅ |
| GCC 14 (Docker) | C++20 | 33/33 ✅ |
| MSVC 19.51 (Wine) | C++20 | compiles cleanly ✅ |

Closes #622.