### PR TITLE
fix: skip process_event in transitions_sub when event not in sub-SM events (#685)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1457,9 +1457,19 @@ struct transitions_sub<sm<Tsm>, T, Ts...> {
 };
 template <class Tsm>
 struct transitions_sub<sm<Tsm>> {
-  template <class TEvent, class SM, class TDeps, class TSubs>
+  template <class TEvent, class SM, class TDeps, class TSubs,
+            BOOST_SML_DETAIL_REQUIRES(aux::is_base_of<get_generic_t<TEvent>, typename sm_impl<Tsm>::events_ids_t>::value ||
+                                      aux::is_base_of<get_mapped_t<TEvent>, typename sm_impl<Tsm>::events_ids_t>::value ||
+                                      aux::is_base_of<entry_exit, TEvent>::value)>
   constexpr static bool execute(const TEvent &event, SM &, TDeps &deps, TSubs &subs, typename SM::state_t &) {
     return sub_sm<sm_impl<Tsm>>::get(&subs).process_event(event, deps, subs);
+  }
+  template <class TEvent, class SM, class TDeps, class TSubs,
+            BOOST_SML_DETAIL_REQUIRES(!aux::is_base_of<get_generic_t<TEvent>, typename sm_impl<Tsm>::events_ids_t>::value &&
+                                      !aux::is_base_of<get_mapped_t<TEvent>, typename sm_impl<Tsm>::events_ids_t>::value &&
+                                      !aux::is_base_of<entry_exit, TEvent>::value)>
+  constexpr static bool execute(const TEvent &, SM &, TDeps &, TSubs &, typename SM::state_t &) {
+    return false;
   }
   template <class, class SM, class TDeps, class TSubs>
   constexpr static bool execute(const anonymous &, SM &, TDeps &deps, TSubs &subs, typename SM::state_t &) {

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -112,4 +112,9 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_580_process_events.cpp)
   add_test(test_issue_580_process_events test_issue_580_process_events)
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_685_transitions_sub_bloat.cpp)
+  add_executable(test_issue_685_transitions_sub_bloat issue_685_transitions_sub_bloat.cpp)
+  add_test(test_issue_685_transitions_sub_bloat test_issue_685_transitions_sub_bloat)
+endif()
+
 add_subdirectory(errors)

--- a/test/ft/issue_685_transitions_sub_bloat.cpp
+++ b/test/ft/issue_685_transitions_sub_bloat.cpp
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2016-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// Regression test for issue #685:
+// transitions_sub<sm<Tsm>>::execute() now skips process_event() when TEvent is
+// not in the sub-SM's events_ids_t, avoiding unnecessary template instantiations
+// that inflate binary size.
+//
+#include <boost/sml.hpp>
+
+namespace sml = boost::sml;
+
+struct e1 {};
+struct e2 {};
+struct e3 {};
+struct e4 {};  // outer-only event, sub-SM has no handler for this
+
+const auto idle = sml::state<class idle>;
+const auto s1 = sml::state<class s1>;
+const auto s2 = sml::state<class s2>;
+
+// Sub-SM handles only e1 and e2 (not e3, not e4).
+test transitions_sub_bloat_unknown_event_ignored = [] {
+  struct sub {
+    auto operator()() noexcept {
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> = s1, s1 + event<e2> = idle);
+    }
+  };
+
+  struct outer {
+    auto operator()() noexcept {
+      using namespace sml;
+      return make_transition_table(*idle + event<e3> = state<sub>, state<sub> + event<e4> = s2);
+    }
+  };
+
+  sml::sm<outer> sm{};
+
+  // Outer transitions from idle to sub via e3
+  sm.process_event(e3{});
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(idle));
+
+  // Sub-SM handles e1 (known event → forwarded)
+  sm.process_event(e1{});
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(s1));
+
+  // e4 is an outer-only event: sub-SM returns false quickly (no instantiation of sub-SM's process_event<e4>)
+  // Outer SM then handles e4 → transitions to s2
+  sm.process_event(e4{});
+  expect(sm.is(s2));
+};
+
+// Verify sub-SM internal events still work correctly after the SFINAE gate
+test transitions_sub_bloat_known_events_forwarded = [] {
+  struct sub {
+    auto operator()() noexcept {
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> = s1, s1 + event<e2> = idle);
+    }
+  };
+
+  struct outer {
+    auto operator()() noexcept {
+      using namespace sml;
+      return make_transition_table(*idle + event<e3> = state<sub>, state<sub> + event<e4> = s2);
+    }
+  };
+
+  sml::sm<outer> sm{};
+  sm.process_event(e3{});
+  expect(sm.is(sml::state<sub>));
+
+  // e1 and e2 are in sub's events_ids_t → correctly forwarded
+  sm.process_event(e1{});
+  expect(sm.is<decltype(sml::state<sub>)>(s1));
+  sm.process_event(e2{});
+  expect(sm.is<decltype(sml::state<sub>)>(idle));
+  sm.process_event(e1{});
+  expect(sm.is<decltype(sml::state<sub>)>(s1));
+};

--- a/test/ft/issue_685_transitions_sub_bloat.cpp
+++ b/test/ft/issue_685_transitions_sub_bloat.cpp
@@ -10,6 +10,7 @@
 // not in the sub-SM's events_ids_t, avoiding unnecessary template instantiations
 // that inflate binary size.
 //
+// cppcheck-suppress missingIncludeSystem
 #include <boost/sml.hpp>
 
 namespace sml = boost::sml;


### PR DESCRIPTION
## Problem

Every event dispatched by the outer SM caused a full `sm_impl<SubSM>::process_event<TEvent>()` instantiation in `transitions_sub<sm<Tsm>>::execute()`, even when `TEvent` is not in the sub-SM's `events_ids_t` and can never be handled.  With a large outer SM and small sub-SMs this multiplies template instantiations and inflates binary size.

## Fix

Split `transitions_sub<sm<Tsm>>::execute()` (the terminal, no-fallback specialisation) into two SFINAE-gated overloads:

- **Forward**: when `get_generic_t<TEvent>` OR `get_mapped_t<TEvent>` appears in `sm_impl<Tsm>::events_ids_t`, **or** when `TEvent` is an `on_entry`/`on_exit` event (detected via `is_base_of<entry_exit, TEvent>`) — calls `process_event` as before.
- **Skip**: when neither generic nor mapped type is in `events_ids_t` and the event is not an entry/exit event — returns `false` immediately, avoiding the instantiation entirely.

`on_entry<>` / `on_exit<>` events are always forwarded so that sub-SM initialisation and cleanup are never suppressed (these events reach the terminal case when dispatched via the `transitions<true_type>` mapping from `process_internal_events` for the initial `on_entry<_, initial>` startup).

The `anonymous{}` overload is unchanged.

## Test

`test/ft/issue_685_transitions_sub_bloat.cpp` verifies:
1. An outer-only event (not in sub's events) is handled by the outer SM, not forwarded to the sub-SM.
2. Events in the sub-SM's events_ids_t are still correctly forwarded and processed.

GCC C++14/17/20 and MSVC C++20: all ft tests pass.