### PR TITLE
fix: clear sub-SM defer queue when composite state is re-entered (#253)

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2780,6 +2780,12 @@ struct defer : action_base {
     }
   }
 };
+struct clear_defer : action_base {
+  template <class TEvent, class Tsm, class TDeps, class TSubs>
+  constexpr void operator()(const TEvent &, Tsm &sm, TDeps &, TSubs &) const {
+    sm.clear_deferred_events();
+  }
+};
 }  // namespace actions
 }  // namespace front
 using testing = back::policies::testing;
@@ -3512,6 +3518,7 @@ constexpr auto operator""_e() {
 BOOST_SML_DETAIL_UNUSED static front::state<back::terminate_state> X;
 BOOST_SML_DETAIL_UNUSED static front::history_state H;
 BOOST_SML_DETAIL_UNUSED static front::actions::defer defer;
+BOOST_SML_DETAIL_UNUSED static front::actions::clear_defer clear_defer;
 BOOST_SML_DETAIL_UNUSED static front::actions::process process;
 BOOST_SML_DETAIL_UNUSED static front::state<class SML_EVAL> eval;
 template <class... Ts, BOOST_SML_DETAIL_REQUIRES(aux::is_same<aux::bool_list<aux::always<Ts>::value...>,

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2286,6 +2286,11 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
   defer_flag_t defer_again_ = defer_flag_t{};
   typename defer_t::const_iterator defer_it_{};
   typename defer_t::const_iterator defer_end_{};
+  constexpr void clear_deferred_events() { clear_deferred_impl_(aux::integral_constant<bool, !aux::is_same<defer_t, no_policy>::value>{}); }
+
+ private:
+  constexpr void clear_deferred_impl_(aux::false_type) {}
+  constexpr void clear_deferred_impl_(aux::true_type) { defer_.clear(); }
 };
 template <class>
 struct get_explicit_deps {
@@ -3171,7 +3176,7 @@ template <class T, class TSubs, class... Ts, class... THs>
 constexpr void update_composite_states(TSubs &subs, aux::true_type, const aux::type_list<THs...> &) {
   using state_t = typename T::state_t;
   auto &sm = back::sub_sm<T>::get(&subs);
-  (void)sm;
+  sm.clear_deferred_events();
 #if defined(__cpp_fold_expressions)
   ((sm.current_state_[aux::get_id<state_t, THs>((typename T::initial_states_ids_t *)0)] =
         aux::get_id<state_t, THs>((typename T::states_ids_t *)0)),
@@ -3206,7 +3211,9 @@ constexpr void recurse_composite(TSubs &subs, aux::true_type);
 
 template <class T, class TSubs, class... Ts>
 constexpr void update_composite_states(TSubs &subs, aux::false_type, Ts &&...) {
-  back::sub_sm<T>::get(&subs).initialize(typename T::initial_states_t{});
+  auto &sm = back::sub_sm<T>::get(&subs);
+  sm.initialize(typename T::initial_states_t{});
+  sm.clear_deferred_events();
 
   aux::for_each(typename T::initial_states_t{},
                 [&](auto state_identity){

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -122,4 +122,9 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_253_defer_clear_on_exit.cpp)
   add_test(test_issue_253_defer_clear_on_exit test_issue_253_defer_clear_on_exit)
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_643_clear_defer_action.cpp)
+  add_executable(test_issue_643_clear_defer_action issue_643_clear_defer_action.cpp)
+  add_test(test_issue_643_clear_defer_action test_issue_643_clear_defer_action)
+endif()
+
 add_subdirectory(errors)

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -117,4 +117,9 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_685_transitions_sub_bloat.cpp)
   add_test(test_issue_685_transitions_sub_bloat test_issue_685_transitions_sub_bloat)
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_253_defer_clear_on_exit.cpp)
+  add_executable(test_issue_253_defer_clear_on_exit issue_253_defer_clear_on_exit.cpp)
+  add_test(test_issue_253_defer_clear_on_exit test_issue_253_defer_clear_on_exit)
+endif()
+
 add_subdirectory(errors)

--- a/test/ft/issue_253_defer_clear_on_exit.cpp
+++ b/test/ft/issue_253_defer_clear_on_exit.cpp
@@ -1,0 +1,122 @@
+// cppcheck-suppress missingIncludeSystem
+#include <boost/sml.hpp>
+// cppcheck-suppress missingIncludeSystem
+#include <deque>
+// cppcheck-suppress missingIncludeSystem
+#include <queue>
+
+namespace sml = boost::sml;
+using namespace sml;
+
+struct e253_1 {};
+struct e253_to_s2 {};
+struct e253_to_s1 {};
+struct e253_enter {};
+struct e253_exit {};
+
+// Test 1: stale deferred event must NOT fire after sub-SM re-entry + round-trip
+test defer_cleared_on_sub_sm_exit = [] {
+  static int fires = 0;
+
+  struct Nested {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"s1"_s + event<e253_to_s2>         = "s2"_s,
+          "s2"_s + event<e253_1> / defer,
+          "s1"_s + event<e253_1> / [] { fires++; },
+          "s2"_s + event<e253_to_s1>         = "s1"_s
+      );
+    }
+  };
+  struct Outer {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"Init"_s + event<e253_enter>          = state<Nested>,
+          state<Nested> + event<e253_exit>      = "Init"_s
+      );
+    }
+  };
+
+  sm<Outer, defer_queue<std::deque>, process_queue<std::queue>> m;
+
+  // Session 1: enter sub-SM, defer e253_1 in s2, then exit
+  m.process_event(e253_enter{});   // Init → Nested/s1
+  m.process_event(e253_to_s2{});   // s1 → s2
+  m.process_event(e253_1{});       // deferred in s2
+  m.process_event(e253_exit{});    // Nested → Init; sub-SM defer queue cleared
+
+  // Session 2: re-enter, do round-trip s1→s2→s1 — stale e253_1 must NOT fire
+  m.process_event(e253_enter{});   // Init → Nested/s1 (fresh start)
+  fires = 0;
+  m.process_event(e253_to_s2{});
+  m.process_event(e253_to_s1{});   // BUG was: fires == 1 here
+  expect(fires == 0);
+};
+
+// Test 2: deferring still works correctly within a single sub-SM lifetime
+test defer_works_within_sub_sm = [] {
+  static int fires = 0;
+
+  struct Nested {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"s1"_s + event<e253_to_s2>         = "s2"_s,
+          "s2"_s + event<e253_1> / defer,
+          "s1"_s + event<e253_1> / [] { fires++; },
+          "s2"_s + event<e253_to_s1>         = "s1"_s
+      );
+    }
+  };
+  struct Outer {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"Init"_s + event<e253_enter>          = state<Nested>,
+          state<Nested> + event<e253_exit>      = "Init"_s
+      );
+    }
+  };
+
+  sm<Outer, defer_queue<std::deque>, process_queue<std::queue>> m;
+
+  m.process_event(e253_enter{});
+  m.process_event(e253_to_s2{});
+  fires = 0;
+  m.process_event(e253_1{});      // deferred in s2
+  m.process_event(e253_to_s1{});  // s2→s1: deferred e253_1 MUST fire
+  expect(fires == 1);
+};
+
+// Test 3: re-entry without any preceding deferral produces no spurious fires
+test no_spurious_fire_without_defer = [] {
+  static int fires = 0;
+
+  struct Nested {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"s1"_s + event<e253_to_s2>         = "s2"_s,
+          "s2"_s + event<e253_1> / defer,
+          "s1"_s + event<e253_1> / [] { fires++; },
+          "s2"_s + event<e253_to_s1>         = "s1"_s
+      );
+    }
+  };
+  struct Outer {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"Init"_s + event<e253_enter>          = state<Nested>,
+          state<Nested> + event<e253_exit>      = "Init"_s
+      );
+    }
+  };
+
+  sm<Outer, defer_queue<std::deque>, process_queue<std::queue>> m;
+
+  m.process_event(e253_enter{});
+  m.process_event(e253_exit{});   // exit without any deferral
+
+  m.process_event(e253_enter{});  // re-enter
+  fires = 0;
+  m.process_event(e253_to_s2{});
+  m.process_event(e253_to_s1{});
+  expect(fires == 0);
+};

--- a/test/ft/issue_643_clear_defer_action.cpp
+++ b/test/ft/issue_643_clear_defer_action.cpp
@@ -1,0 +1,83 @@
+// cppcheck-suppress missingIncludeSystem
+#include <boost/sml.hpp>
+// cppcheck-suppress missingIncludeSystem
+#include <deque>
+// cppcheck-suppress missingIncludeSystem
+#include <queue>
+
+namespace sml = boost::sml;
+using namespace sml;
+
+struct e643_go {};
+struct e643_ret {};
+struct e643_back {};
+struct e643_deferred_ev {};
+
+// Test: sml::clear_defer action discards pending deferred events
+test clear_defer_action_discards_deferred = [] {
+  static int fires = 0;
+
+  struct Sub643 {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"a"_s + event<e643_go>           = "b"_s,
+          "b"_s + event<e643_deferred_ev> / defer,
+          "a"_s + event<e643_deferred_ev> / [] { fires++; },
+          "b"_s + event<e643_ret>           = "a"_s
+      );
+    }
+  };
+  struct Outer643 {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"outer_a"_s + event<e643_go>            = state<Sub643>,
+          // clear_defer on the way out so stale events don't survive
+          state<Sub643> + event<e643_back> / clear_defer = "outer_a"_s
+      );
+    }
+  };
+
+  sm<Outer643, defer_queue<std::deque>, process_queue<std::queue>> m;
+
+  // Enter sub-SM, defer an event in state "b", then exit with clear_defer
+  m.process_event(e643_go{});         // outer_a → Sub643/a
+  m.process_event(e643_go{});         // a → b
+  m.process_event(e643_deferred_ev{}); // deferred in b
+  m.process_event(e643_back{});        // exit Sub643 with clear_defer action
+
+  // Re-enter and do round-trip — the cleared event must not fire
+  m.process_event(e643_go{});          // outer_a → Sub643/a
+  fires = 0;
+  m.process_event(e643_go{});          // a → b
+  m.process_event(e643_ret{});         // b → a: no stale deferred event
+  expect(fires == 0);
+};
+
+// Test: clear_defer is a no-op when defer queue is already empty
+test clear_defer_noop_when_empty = [] {
+  static int fires = 0;
+
+  struct Inner643 {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"x"_s + event<e643_deferred_ev> / [] { fires++; }
+      );
+    }
+  };
+  struct Outer643b {
+    auto operator()() const noexcept {
+      return make_transition_table(
+         *"init"_s + event<e643_go>            = state<Inner643>,
+          state<Inner643> + event<e643_back> / clear_defer = "init"_s
+      );
+    }
+  };
+
+  sm<Outer643b, defer_queue<std::deque>, process_queue<std::queue>> m;
+  m.process_event(e643_go{});
+  m.process_event(e643_back{});  // clear_defer on empty queue — must not crash
+  fires = 0;
+  m.process_event(e643_go{});
+  m.process_event(e643_deferred_ev{});  // normal event fires in x state
+  expect(fires == 1);
+};


### PR DESCRIPTION
## Commit 1 — fix: clear sub-SM defer queue on composite re-entry (#253)

**Root cause:** Each `sm_impl` holds its own `defer_` queue (same policy as the root, propagated via `TPolicies`). `process_defer_events` replays events from this queue on the next internal transition inside the sub-SM. `update_composite_states` resets `current_state_[]` via `initialize()` when a composite is entered, but never cleared `defer_`. Events deferred in a prior session fired spuriously on the first internal transition of the next session.

**Fix:** Added `clear_deferred_events()` to `sm_impl`, tag-dispatched on `is_same<defer_t, no_policy>` for C++14 compatibility. Called in both `update_composite_states` overloads (history and non-history) so the defer queue is always emptied when a composite state is (re-)entered.

**Tests:** `test/ft/issue_253_defer_clear_on_exit.cpp` — 3 cases: stale event must not fire after exit + re-entry + round-trip; normal deferral still works within a session; no spurious fires without prior deferral.

---

## Commit 2 — feat: add `sml::clear_defer` action (#643)

Exposes the new `clear_deferred_events()` infrastructure as a user-accessible action object (`sml::clear_defer`, alongside `sml::defer` and `sml::process`). Lets users explicitly discard pending deferred events on a specific outgoing transition:

```cpp
state<Nested> + event<EXIT> / clear_defer = "Init"_s
```

**Tests:** `test/ft/issue_643_clear_defer_action.cpp` — user-controlled clear discards stale deferred events; no-op on empty queue.

---

Verified: GCC 14 + Clang 18, C++14/17/20 (39–40/40 tests pass). MSVC 19.51 C++20 clean.