### PR TITLE
feat(#629): add sml::make_action<Deps...>(f) for template/constrained callable actions

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1041,6 +1041,17 @@ template <class T>
 constexpr auto wrap(T callback) {
   return aux::zero_wrapper<T, T>{callback};
 }
+template <class F, class... TDeps>
+struct action_wrap {
+  constexpr explicit action_wrap(F f) : f_(f) {}
+  constexpr auto operator()(TDeps... args) const { return f_(args...); }
+ private:
+  F f_;
+};
+template <class... TDeps, class F>
+constexpr auto make_action(F f) {
+  return action_wrap<F, TDeps...>{f};
+}
 namespace back {
 namespace policies {
 struct defer_queue_policy__ {};

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -137,4 +137,9 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_456_flush_queue.cpp)
   add_test(test_issue_456_flush_queue test_issue_456_flush_queue)
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_629_action_wrap.cpp)
+  add_executable(test_issue_629_action_wrap issue_629_action_wrap.cpp)
+  add_test(test_issue_629_action_wrap test_issue_629_action_wrap)
+endif()
+
 add_subdirectory(errors)

--- a/test/ft/issue_629_action_wrap.cpp
+++ b/test/ft/issue_629_action_wrap.cpp
@@ -1,0 +1,78 @@
+// cppcheck-suppress missingIncludeSystem
+#include <boost/sml.hpp>
+
+namespace sml = boost::sml;
+
+struct trigger {};
+struct MyDep {
+    int called = 0;
+};
+
+// Generic lambda: without sml::make_action<> the args_ probe instantiates op() with
+// the event type and concludes the callable wants the event, not the dep.
+// sml::make_action<MyDep&> provides an explicit concrete signature so function_traits
+// can extract the right dep type.
+test action_wrap_generic_action = [] {
+    struct SM {
+        auto operator()() const {
+            using namespace sml;
+            return make_transition_table(
+                *"s1"_s + event<trigger> / make_action<MyDep&>([](auto& dep) { dep.called++; }) = X);
+        }
+    };
+    MyDep dep;
+    sml::sm<SM> sm{dep};
+    sm.process_event(trigger{});
+    expect(dep.called == 1);
+    expect(sm.is(sml::X));
+};
+
+test action_wrap_generic_guard = [] {
+    struct SM {
+        auto operator()() const {
+            using namespace sml;
+            return make_transition_table(
+                *"s1"_s + event<trigger>[make_action<MyDep&>([](auto& dep) { return dep.called == 0; })] = X);
+        }
+    };
+    MyDep dep;
+    sml::sm<SM> sm{dep};
+    sm.process_event(trigger{});
+    expect(sm.is(sml::X));
+};
+
+test action_wrap_event_and_dep = [] {
+    struct SM {
+        auto operator()() const {
+            using namespace sml;
+            return make_transition_table(
+                *"s1"_s + event<trigger> /
+                    make_action<const trigger&, MyDep&>([](const auto& /*e*/, auto& dep) { dep.called++; }) = X);
+        }
+    };
+    MyDep dep;
+    sml::sm<SM> sm{dep};
+    sm.process_event(trigger{});
+    expect(dep.called == 1);
+    expect(sm.is(sml::X));
+};
+
+#if __cplusplus >= 202002L
+template <typename T>
+concept HasCalled = requires(T t) { t.called; };
+
+test action_wrap_constrained_auto = [] {
+    struct SM {
+        auto operator()() const {
+            using namespace sml;
+            return make_transition_table(
+                *"s1"_s + event<trigger> / make_action<MyDep&>([](HasCalled auto& dep) { dep.called++; }) = X);
+        }
+    };
+    MyDep dep;
+    sml::sm<SM> sm{dep};
+    sm.process_event(trigger{});
+    expect(dep.called == 1);
+    expect(sm.is(sml::X));
+};
+#endif


### PR DESCRIPTION
Fixes #629

## Root cause

`args_t<F, E>` probes callable argument types via `&T::operator()<EventType>` and `&T::operator()`. For any callable with a **template** `operator()` — including C++20 constrained-auto lambdas (`[](Concept auto x){}`) and C++14/17 generic lambdas used for dep injection (`[](auto x){}`) — both probes fail and the callable falls through to the `action_base` path, which passes the raw SML internal context `(event, sm, deps, subs)` instead of the intended dep. This causes a hard compile error.

## Fix

Add `sml::action_wrap<F, TDeps...>` — a thin wrapper with a **concrete** `operator()(TDeps...)` that `function_traits` can decompose via the standard `args1_` probe. The public factory function is `sml::make_action<Deps...>(callable)`.

```cpp
// C++20: constrained-auto
const auto send_fin = sml::make_action<Foo&>([](Foolike auto& dep) { dep.process(); });

// C++14/17: generic lambda where arg is a dep (not the event)
const auto my_action = sml::make_action<MyDep&>([](auto& dep) { dep.value++; });

// event + dep
const auto handle = sml::make_action<const Event&, Foo&>([](const auto& e, auto& dep) { ... });

// guard (bool return works identically)
const auto check = sml::make_action<MyDep&>([](auto& dep) { return dep.ready; });
```

## Implementation

- `action_wrap<F, TDeps...>`: concrete `operator()(TDeps...) const` that forwards to the inner callable. ~8 lines, placed alongside `wrap()`.
- `make_action<TDeps...>(f)`: factory function returning `action_wrap`. ~3 lines.
- No changes to `args_t`, `call<>`, `zero_wrapper`, or any existing dispatch path. Purely additive.

The name `make_action` was chosen over `action` to avoid collision with the common user pattern `struct action { ... }` with `using namespace sml`.

## Tests

`test/ft/issue_629_action_wrap.cpp` covers:
- Generic lambda → dep injection (C++14/17)
- Generic lambda guard
- Event + dep
- C++20 constrained-auto (guarded by `#if __cplusplus >= 202002L`)

Verified: GCC C++17/20 39/39, MSVC C++20 compile+link clean.