### PR TITLE
feat(#456): add sm::flush_queue() to drain process_ queue from async handlers

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2011,6 +2011,15 @@ struct sm_impl : aux::conditional_t<aux::should_not_subclass_statemachine_class<
     } while (process_queued_events(d, subs, queued_handled, aux::type_wrapper<process_queue_t<TEvent>>{}, events_t{}));
     return handled && queued_handled;
   }
+  template <class TDeps, class TSubs>
+  constexpr void flush_queue(TDeps &d, TSubs &subs) {
+    const auto lock = thread_safety_.create_lock();
+    (void)lock;
+    bool queued_handled = true;
+    do {
+      while (process_internal_events(anonymous{}, d, subs)) {}
+    } while (process_queued_events(d, subs, queued_handled, aux::type_wrapper<process_t>{}, events_t{}));
+  }
   constexpr void initialize(const aux::type_list<> &) {}
   template <class TState>
   constexpr void initialize(const aux::type_list<TState> &) {
@@ -2366,6 +2375,9 @@ class sm {
   template <class TEvent, BOOST_SML_DETAIL_REQUIRES(!aux::is_base_of<TEvent, events_ids>::value)>
   constexpr bool process_event(const TEvent &event) {
     return aux::get<sm_impl<Tsm>>(sub_sms_).process_event(unexpected_event<_, TEvent>{event}, deps_, sub_sms_);
+  }
+  constexpr void flush_queue() {
+    aux::get<sm_impl<Tsm>>(sub_sms_).flush_queue(deps_, sub_sms_);
   }
   template <class T = aux::identity<sm_t>, class TVisitor, BOOST_SML_DETAIL_REQUIRES(concepts::callable<void, TVisitor>::value)>
   constexpr void visit_current_states(const TVisitor &visitor) const {

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -132,4 +132,9 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_622_any_state_nested.cpp)
   add_test(test_issue_622_any_state_nested test_issue_622_any_state_nested)
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/issue_456_flush_queue.cpp)
+  add_executable(test_issue_456_flush_queue issue_456_flush_queue.cpp)
+  add_test(test_issue_456_flush_queue test_issue_456_flush_queue)
+endif()
+
 add_subdirectory(errors)

--- a/test/ft/issue_456_flush_queue.cpp
+++ b/test/ft/issue_456_flush_queue.cpp
@@ -1,5 +1,6 @@
 // cppcheck-suppress missingIncludeSystem
 #include <boost/sml.hpp>
+// cppcheck-suppress missingIncludeSystem
 #include <queue>
 
 namespace sml = boost::sml;

--- a/test/ft/issue_456_flush_queue.cpp
+++ b/test/ft/issue_456_flush_queue.cpp
@@ -1,0 +1,52 @@
+// cppcheck-suppress missingIncludeSystem
+#include <boost/sml.hpp>
+#include <queue>
+
+namespace sml = boost::sml;
+using namespace sml::literals;
+
+struct e1 {};
+struct e2 {};
+
+struct AsyncHandle {
+  sml::back::process<e2> push{};
+};
+
+struct Fired {
+  bool value = false;
+};
+
+struct SM {
+  auto operator()() const {
+    using namespace sml;
+    return make_transition_table(
+        *"s1"_s + event<e1> / [](back::process<e2> p, AsyncHandle &h) { h.push = p; } = "s2"_s,
+         "s2"_s + event<e2> / [](Fired &f) { f.value = true; } = X);
+  }
+};
+
+// Verify that an event pushed via back::process<> after process_event() returns
+// is processed when flush_queue() is called.
+test flush_queue_processes_async_event = [] {
+  AsyncHandle handle;
+  Fired fired;
+  sml::sm<SM, sml::process_queue<std::queue>> sm{handle, fired};
+
+  sm.process_event(e1{});    // action stores push handle, s1→s2
+  expect(!fired.value);
+
+  handle.push(e2{});         // simulates async callback pushing e2 after process_event returns
+  expect(!fired.value);      // not yet processed
+
+  sm.flush_queue();          // drain: e2 processed, s2→X
+  expect(fired.value);
+  expect(sm.is(sml::X));
+};
+
+test flush_queue_noop_when_empty = [] {
+  AsyncHandle handle;
+  Fired fired;
+  sml::sm<SM, sml::process_queue<std::queue>> sm{handle, fired};
+  sm.flush_queue();          // must not crash or hang on empty queue
+  expect(sm.is("s1"_s));
+};


### PR DESCRIPTION
Fixes #456, related to #189

## Problem

`sml::back::process<E>` pushes to the root SM's internal `process_` queue. That queue is drained by `process_queued_events` — but only from within the `process_event()` loop. When an action captures a `back::process<E>` handle and stores it for use in an async completion handler (e.g. an asio timer callback), the handler fires *after* `process_event()` has returned. The pushed event sits in `process_` with no trigger to drain it.

## Fix

Add `sm::flush_queue()` — a public method that drains `process_` and runs anonymous transitions, using the same thread-safety lock as `process_event()`.

```cpp
// sm_impl (new private method):
template <class TDeps, class TSubs>
constexpr void flush_queue(TDeps &d, TSubs &subs) {
  const auto lock = thread_safety_.create_lock();
  bool queued_handled = true;
  do {
    while (process_internal_events(anonymous{}, d, subs)) {}
  } while (process_queued_events(d, subs, queued_handled,
                                  aux::type_wrapper<process_t>{}, events_t{}));
}

// sm (new public method):
constexpr void flush_queue() {
  aux::get<sm_impl<Tsm>>(sub_sms_).flush_queue(deps_, sub_sms_);
}
```

## Usage

```cpp
// In an async completion handler (e.g. asio timer):
timer->async_wait([processEvent](auto ec) {
  if (!ec) {
    processEvent(timerExpired{});  // push to queue
    sm->flush_queue();             // drain it
  }
});
```

Works correctly with `sml::thread_safe<std::recursive_mutex>` since `flush_queue()` acquires the same lock.

## Tests

`test/ft/issue_456_flush_queue.cpp`:
- Verifies that an event pushed via a stored `back::process<>` handle after `process_event()` returns is processed by `flush_queue()`
- Verifies `flush_queue()` is a no-op on an empty queue

Verified: GCC C++17/20 40/40, MSVC C++20 compile clean.