### PR TITLE
Make transition_sa and transition_sg constructors constexpr

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -3135,7 +3135,7 @@ struct transition<state<S1>, state<S2>> : transition<state<S1>, state<S2>, front
 template <class S2, class G>
 struct transition_sg<state<S2>, G> : transition<state<internal>, state<S2>, front::event<back::anonymous>, G, none> {
   using transition<state<internal>, state<S2>, front::event<back::anonymous>, G, none>::g;
-  transition_sg(const state<S2> &, const G &g_init)
+  constexpr transition_sg(const state<S2> &, const G &g_init)
       : transition<state<internal>, state<S2>, front::event<back::anonymous>, G, none>{g_init, none{}} {}
   template <class T>
   constexpr auto operator/(const T &t) const {
@@ -3149,7 +3149,7 @@ struct transition_sg<state<S2>, G> : transition<state<internal>, state<S2>, fron
 template <class S2, class A>
 struct transition_sa<state<S2>, A> : transition<state<internal>, state<S2>, front::event<back::anonymous>, always, A> {
   using transition<state<internal>, state<S2>, front::event<back::anonymous>, always, A>::a;
-  transition_sa(const state<S2> &, const A &a_init)
+  constexpr transition_sa(const state<S2> &, const A &a_init)
       : transition<state<internal>, state<S2>, front::event<back::anonymous>, always, A>{always{}, a_init} {}
   template <class T>
   constexpr auto operator=(const T &) const {

--- a/test/ft/constexpr.cpp
+++ b/test/ft/constexpr.cpp
@@ -13,6 +13,8 @@ namespace sml = boost::sml;
 struct e1 {};
 
 const auto idle = sml::state<class idle>;
+const auto s1 = sml::state<class s1>;
+const auto s2 = sml::state<class s2>;
 
 test constexpr_sm = [] {
   using namespace sml;
@@ -36,4 +38,24 @@ test constexpr_sm = [] {
   };
 
   static_assert(test());
+};
+
+test constexpr_anonymous_transitions_sm = [] {
+  using namespace sml;
+  struct c {
+    // clang-format off
+    constexpr auto operator()() noexcept {
+      const auto guard = [] { return true; };
+      const auto action = [] {};
+      return make_transition_table(
+        *idle + event<e1> = s1,
+         s1[guard]        = s2,
+         s2 / action      = X
+      );
+    }
+    // clang-format on
+  };
+
+  constexpr sml::sm<c, sml::dispatch<sml::back::policies::branch_stm>> sm{};
+  (void)sm;
 };


### PR DESCRIPTION
Every fully-formed `transition<…>` constructor is already `constexpr`, but the two anonymous-transition intermediates are not: `transition_sa` and `transition_sg`.

This meant a transition table containing such a row couldn't be built in a constant expression, blocking `constinit` / static initialization of an `sm<>` that uses one.

Both just forward to already-`constexpr` base constructors, so it's a one-word change per type with no behavioral or ABI impact. Includes a regression test in `test/ft/constexpr.cpp` that fails to compile without the fix.